### PR TITLE
veza@0.3.0 release

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,12 @@
 {
 	"extends": "klasa",
 	"rules": {
-		"operator-linebreak": ["error", "before", { "overrides": { "+": "after" } }],
+		"arrow-parens": ["error", "always"],
 		"curly": ["error", "multi-or-nest", "consistent"],
 		"id-length": "off",
 		"no-bitwise": ["error", { "int32Hint": true }],
-		"no-cond-assign": "off"
+		"no-cond-assign": "off",
+		"operator-linebreak": ["error", "before", { "overrides": { "+": "after" } }]
 	},
 	"globals": {
 		"BigInt": true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,5 +6,8 @@
 		"id-length": "off",
 		"no-bitwise": ["error", { "int32Hint": true }],
 		"no-cond-assign": "off"
+	},
+	"globals": {
+		"BigInt": true
 	}
 }

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+**The issue tracker is only for issue reporting or proposals/suggestions**.
+
+To contribute to this repository, feel free to create a new fork of the repository
+submit a pull request. We highly suggest [ESLint](https://eslint.org/) to be installed
+in your text editor or IDE of your choice to avoid fail builds from Travis.
+
+1. Fork, clone, and select the **master** branch.
+2. Create a new branch in your fork.
+3. Commit your changes, and push them.
+4. Submit a Pull Request [here](https://github.com/kyranet/veza/pulls)!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+### Describe the issue
+
+### Code or steps to reproduce
+
+```js
+
+```
+
+<!--
+If your issue is a proposal, you can provide its use case showing code.
+Make sure to explain everything well and comment the code, so we can
+follow up.
+-->
+
+### Expected and actual behavior
+
+### Further details
+
+- **node.js version**:
+- **veza version**:
+- [ ] I have tested the issue on latest master. Commit hash:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+### Description of the PR
+
+
+### Semver Classification
+
+- [ ] This PR only includes documentation or non-code changes.
+- [ ] This PR fixes a bug and does not change the (intended) API/interface.
+- [ ] This PR adds methods or properties to the API/interface.
+- [ ] This PR removes or renames methods or properties in the API/interface.

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,21 @@
+# Packages
+node_modules/
+yarn.lock
+
+# Log files
+logs/
+*.log
+
+# Miscellaneous
+.tmp/
+.vscode/
+docs/
+
+# NPM ignore
+.eslintignore
+.eslintrc.json
+.gitattributes
+.gitignore
+.travis.yml
+tslint.json
+test/

--- a/.npmignore
+++ b/.npmignore
@@ -15,7 +15,8 @@ docs/
 .eslintignore
 .eslintrc.json
 .gitattributes
+.github/
 .gitignore
 .travis.yml
-tslint.json
 test/
+tslint.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Veza
 
+<div align="center">
+  <p>
+    <a href="https://www.npmjs.com/kyranet/veza"><img src="https://img.shields.io/npm/v/veza.svg?maxAge=3600" alt="NPM version" /></a>
+    <a href="https://www.npmjs.com/kyranet/veza"><img src="https://img.shields.io/npm/dt/veza.svg?maxAge=3600" alt="NPM downloads" /></a>
+    <a href="https://travis-ci.org/kyranet/veza"><img src="https://travis-ci.org/kyranet/veza.svg" alt="Build status" /></a>
+    <a href="https://david-dm.org/kyranet/veza"><img src="https://img.shields.io/david/kyranet/veza.svg?maxAge=3600" alt="Dependencies" /></a>
+    <a href="https://www.patreon.com/kyranet"><img src="https://img.shields.io/badge/donate-patreon-F96854.svg" alt="Patreon" /></a>
+  </p>
+  <p>
+    <a href="https://nodei.co/npm/veza/"><img src="https://nodei.co/npm/veza.png?downloads=true&stars=true" alt="npm installnfo" /></a>
+  </p>
+</div>
+
 **Veza** is a lower level version of [IPC-Link](https://github.com/kyranet/ipc-link)
 that is lightning fast and operates with raw buffers as opposed to sending buffered
 stringified JSON objects. This library has no dependencies and uses built-in modules

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@
     <a href="https://www.npmjs.com/kyranet/veza"><img src="https://img.shields.io/npm/v/veza.svg?maxAge=3600" alt="NPM version" /></a>
     <a href="https://www.npmjs.com/kyranet/veza"><img src="https://img.shields.io/npm/dt/veza.svg?maxAge=3600" alt="NPM downloads" /></a>
     <a href="https://travis-ci.org/kyranet/veza"><img src="https://travis-ci.org/kyranet/veza.svg" alt="Build status" /></a>
-    <a href="https://david-dm.org/kyranet/veza"><img src="https://img.shields.io/david/kyranet/veza.svg?maxAge=3600" alt="Dependencies" /></a>
     <a href="https://www.patreon.com/kyranet"><img src="https://img.shields.io/badge/donate-patreon-F96854.svg" alt="Patreon" /></a>
   </p>
   <p>
     <a href="https://nodei.co/npm/veza/"><img src="https://nodei.co/npm/veza.png?downloads=true&stars=true" alt="npm installnfo" /></a>
   </p>
 </div>
+
+## About
 
 **Veza** is a lower level version of [IPC-Link](https://github.com/kyranet/ipc-link)
 that is lightning fast and operates with raw buffers as opposed to sending buffered

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# IPC-Link Core
+# Veza
 
-**IPC-Link Core** is a lower level version of [IPC-Link](https://github.com/kyranet/ipc-link) that is lightning fast and operates with raw buffers as opposed to sending buffered stringified JSON objects. This library has no dependencies and uses built-in modules (`net`, `events`...) to operate.
+**Veza** is a lower level version of [IPC-Link](https://github.com/kyranet/ipc-link) that is lightning fast and operates with raw buffers as opposed to sending buffered stringified JSON objects. This library has no dependencies and uses built-in modules (`net`, `events`...) to operate.
 
-In IPC-Link Core, you have "nodes", which can either create a server (and receive messages) or connect to other servers, even both at the same time. Additionally, you have `Node#sendTo(socket, data);` which will wait for the socket to reply back.
+In Veza, you have "nodes", which can either create a server (and receive messages) or connect to other servers, even both at the same time. Additionally, you have `Node#sendTo(socket, data);` which will wait for the socket to reply back.
 
 ## Usage
 
-Check the examples [here](https://github.com/kyranet/ipc-link-core/tree/master/test) for working micro **IPC-Link Core** applications.
+Check the examples [here](https://github.com/kyranet/veza/tree/master/test) for working micro **Veza** applications.
 
 `hello.js`
 
 ```javascript
 // This example must be run before interactive/world, since this serves the
 // IPC server the other sockets connect to.
-const { Node } = require('ipc-link-core');
+const { Node } = require('veza');
 
 const node = new Node('hello')
 	.on('connection', (name, socket) => {
@@ -34,7 +34,7 @@ const node = new Node('hello')
 // This example depends on hello.js to be running in another process.
 // This Node is a socket that replies to hello.js with "world!" when it
 // receives "Hello".
-const { Node } = require('ipc-link-core');
+const { Node } = require('veza');
 
 const node = new Node('world')
 	.on('message', (message) => {
@@ -53,7 +53,10 @@ node.connectTo('hello', 8001)
 
 The differences with IPC-Link are:
 
-- **IPC-Link Core** does not rely on **node-ipc**, but rather uses `net.Socket`, `net.Server` and `events.EventEmitter`.
-- **IPC-Link Core** does not use JSON objects: it uses buffers with headers.
-- **IPC-Link Core** does not abstract `net.Socket#connect` nor `net.Server#listen`, as opposed to what **node-ipc** does.
-- **IPC-Link Core** does not send a message to a socket if it's not connected, you must connect first (in node-ipc, it attempts to connect using the name, which breaks in many cases and leads to unexpected behaviour).
+- **Veza** does not rely on **node-ipc**, but rather uses `net.Socket`, `net.Server` and `events.EventEmitter`.
+- **Veza** does not use JSON objects: it uses buffers with headers.
+- **Veza** does not abstract `net.Socket#connect` nor `net.Server#listen`, as opposed to what **node-ipc** does.
+- **Veza** does not send a message to a socket if it's not connected, you must connect first (in node-ipc, it attempts to connect using the name, which breaks in many cases and leads to unexpected behaviour).
+- **Veza** supports recurrency as opposed to blocking message queues.
+
+> Originally, **Veza** was called **ipc-link-core**.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **Veza** is a lower level version of [IPC-Link](https://github.com/kyranet/ipc-link) that is lightning fast and operates with raw buffers as opposed to sending buffered stringified JSON objects. This library has no dependencies and uses built-in modules (`net`, `events`...) to operate.
 
-In Veza, you have "nodes", which can either create a server (and receive messages) or connect to other servers, even both at the same time. Additionally, you have `Node#sendTo(socket, data);` which will wait for the socket to reply back.
+In Veza, you have "nodes", which can either create a server (and receive messages) or connect to other servers, even both at the same time. Additionally, you have `client.send(data);` which will wait for the socket to reply back.
+
+> One of Veza's special features is the ability to glue split messages and split concatenated messages, for which it uses a 13-bit "header" (encoded in base-256 to take avantage of the byte range `0x00`-`0xFF`) at the start of every message containing the id, the datatype, the receptive flag, and the length of the message (4.2gb maximum size).
 
 ## Usage
 
@@ -11,43 +13,41 @@ Check the examples [here](https://github.com/kyranet/veza/tree/master/test) for 
 `hello.js`
 
 ```javascript
-// This example must be run before interactive/world, since this serves the
-// IPC server the other sockets connect to.
 const { Node } = require('veza');
 
 const node = new Node('hello')
-	.on('connection', (name, socket) => {
-		console.log(`Connected to ${name}`);
-		node.sendTo(socket, 'Hello')
-			.then(reply => console.log(`Hello ${reply}`));
+	.on('client.connect', (client) => console.log(`[IPC] Client Connected: ${client.name}`))
+	.on('client.disconnect', (client) => console.log(`[IPC] Client Disconnected: ${client.name}`))
+	.on('client.destroy', (client) => console.log(`[IPC] Client Destroyed: ${client.name}`))
+	.on('server.ready', (server) => console.log(`[IPC] Client Ready: Named ${server.name}`))
+	.on('message', (message) => {
+		console.log(`Received data:`, message.data);
+		message.reply(message.data);
 	})
-	.on('listening', console.log.bind(null, 'Listening'))
-	.on('message', console.log.bind(null, 'Message'))
-	.on('error', console.error.bind(null, 'Error'))
-	.on('socketClose', console.log.bind(null, 'Closed Socket:'))
-	.serve('hello', 8001);
+	.on('error', (error, client) => console.error(`[IPC] Error from ${client.name}`, error))
+	.serve(8001);
 ```
 
 `world.js`
 
 ```javascript
-// This example depends on hello.js to be running in another process.
-// This Node is a socket that replies to hello.js with "world!" when it
-// receives "Hello".
 const { Node } = require('veza');
 
 const node = new Node('world')
-	.on('message', (message) => {
-		console.log(`Received data from ${message.from}:`, message);
-		if (message.data === 'Hello')
-			message.reply('world!');
-	})
-	.on('error', console.error)
-	.on('connect', () => console.log('Connected!'));
+	.on('error', (error, client) => console.error(`[IPC] Error from ${client.name}:`, error))
+	.on('client.disconnect', (client) => console.error(`[IPC] Disconnected from ${client.name}`))
+	.on('client.ready', (client) => {
+		console.log(`[IPC] Connected to: ${client.name}`);
+		client.send('Hello', { timeout: 5000 })
+			.then((result) => console.log(`[TEST] Hello ${result}`))
+			.catch((error) => console.error(`[TEST] Client send errored: ${error}`));
+	});
 
 node.connectTo('hello', 8001)
-	.catch(() => console.log('Disconnected!'));
+	.catch((error) => console.error('[IPC] Disconnected!', error));
 ```
+
+> If you run `hello.js` (aka server), and in another window, `world.js`, world will connect to hello, once ready, it will send hello "Hello", for which the server will reply with "world!", logging from the latter "Hello world!" in the terminal.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # Veza
 
-**Veza** is a lower level version of [IPC-Link](https://github.com/kyranet/ipc-link) that is lightning fast and operates with raw buffers as opposed to sending buffered stringified JSON objects. This library has no dependencies and uses built-in modules (`net`, `events`...) to operate.
+**Veza** is a lower level version of [IPC-Link](https://github.com/kyranet/ipc-link)
+that is lightning fast and operates with raw buffers as opposed to sending buffered
+stringified JSON objects. This library has no dependencies and uses built-in modules
+(`net`, `events`...) to operate.
 
-In Veza, you have "nodes", which can either create a server (and receive messages) or connect to other servers, even both at the same time. Additionally, you have `client.send(data);` which will wait for the socket to reply back.
+In Veza, you have "nodes", which can either create a server (and receive messages)
+or connect to other servers, even both at the same time. Additionally, you have
+`client.send(data);` which will wait for the socket to reply back.
 
-> One of Veza's special features is the ability to glue split messages and split concatenated messages, for which it uses a 13-bit "header" (encoded in base-256 to take avantage of the byte range `0x00`-`0xFF`) at the start of every message containing the id, the datatype, the receptive flag, and the length of the message (4.2gb maximum size).
+> One of Veza's special features is the ability to glue truncated messages and split
+concatenated messages, for which it uses a 13-bit "header" (encoded in base-256 to
+take avantage of the byte range `0x00`-`0xFF`) at the start of every message containing
+the id, the datatype, the receptive flag, and the length of the message (4.2gb
+maximum size).
 
 ## Usage
 
-Check the examples [here](https://github.com/kyranet/veza/tree/master/test) for working micro **Veza** applications.
+Check the examples [here](https://github.com/kyranet/veza/tree/master/test) for
+working micro **Veza** applications.
 
 `hello.js`
 
@@ -47,16 +57,22 @@ node.connectTo('hello', 8001)
 	.catch((error) => console.error('[IPC] Disconnected!', error));
 ```
 
-> If you run `hello.js` (aka server), and in another window, `world.js`, world will connect to hello, once ready, it will send hello "Hello", for which the server will reply with "world!", logging from the latter "Hello world!" in the terminal.
+> If you run `hello.js` (aka server), and in another window, `world.js`, world will
+connect to hello, once ready, it will send hello "Hello", for which the server will
+ reply with "world!", logging from the latter "Hello world!" in the terminal.
 
 ---
 
 The differences with IPC-Link are:
 
-- **Veza** does not rely on **node-ipc**, but rather uses `net.Socket`, `net.Server` and `events.EventEmitter`.
+- **Veza** does not rely on **node-ipc**, but rather uses `net.Socket`, `net.Server`
+and `events.EventEmitter`.
 - **Veza** does not use JSON objects: it uses buffers with headers.
-- **Veza** does not abstract `net.Socket#connect` nor `net.Server#listen`, as opposed to what **node-ipc** does.
-- **Veza** does not send a message to a socket if it's not connected, you must connect first (in node-ipc, it attempts to connect using the name, which breaks in many cases and leads to unexpected behaviour).
+- **Veza** does not abstract `net.Socket#connect` nor `net.Server#listen`, as opposed
+to what **node-ipc** does.
+- **Veza** does not send a message to a socket if it's not connected, you must connect
+first (in node-ipc, it attempts to connect using the name, which breaks in many
+cases and leads to unexpected behaviour).
 - **Veza** supports recurrency as opposed to blocking message queues.
 
 > Originally, **Veza** was called **ipc-link-core**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veza",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "IPC Utilities",
   "main": "src/index",
   "types": "typings/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veza",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "IPC Utilities",
   "main": "src/index",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/kyranet/veza#readme",
   "devDependencies": {
-    "@types/node": "^10.5.3",
-    "eslint": "^5.2.0",
+    "@types/node": "^10.9.4",
+    "eslint": "^5.5.0",
     "eslint-config-klasa": "github:dirigeants/klasa-lint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "veza",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "IPC Utilities",
   "main": "src/index",
+  "types": "typings/index.d.ts",
   "scripts": {
     "lint": "eslint --fix src test",
     "test": "eslint src test"
@@ -25,8 +26,8 @@
   },
   "homepage": "https://github.com/kyranet/veza#readme",
   "devDependencies": {
-    "@types/node": "^10.5.1",
-    "eslint": "^5.0.1",
+    "@types/node": "^10.5.3",
+    "eslint": "^5.2.0",
     "eslint-config-klasa": "github:dirigeants/klasa-lint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veza",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "IPC Utilities",
   "main": "src/index",
   "types": "typings/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/kyranet/veza#readme",
   "devDependencies": {
-    "@types/node": "^10.3.2",
-    "eslint": "^4.19.1",
+    "@types/node": "^10.5.1",
+    "eslint": "^5.0.1",
     "eslint-config-klasa": "github:dirigeants/klasa-lint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ipc-link-core",
+  "name": "veza",
   "version": "0.2.0",
   "description": "IPC Utilities",
   "main": "src/index",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:kyranet/ipc-link-core.git"
+    "url": "git@github.com:kyranet/veza.git"
   },
   "keywords": [
     "ipc",
@@ -21,9 +21,9 @@
   "author": "kyraNET",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/kyranet/ipc-link-core/issues"
+    "url": "https://github.com/kyranet/veza/issues"
   },
-  "homepage": "https://github.com/kyranet/ipc-link-core#readme",
+  "homepage": "https://github.com/kyranet/veza#readme",
   "devDependencies": {
     "@types/node": "^10.3.2",
     "eslint": "^4.19.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 module.exports = {
 	Base: require('./lib/Structures/Base/Base'),
 	Node: require('./lib/Node'),
+	NodeMessage: require('./lib/Structures/NodeMessage'),
 	NodeServer: require('./lib/Structures/NodeServer'),
 	NodeServerClient: require('./lib/Structures/NodeServerClient'),
 	NodeSocket: require('./lib/Structures/NodeSocket'),

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,9 @@
-module.exports = { Node: require('./lib/Node') };
+module.exports = {
+	Base: require('./lib/Structures/Base/Base'),
+	Node: require('./lib/Node'),
+	NodeServer: require('./lib/Structures/NodeServer'),
+	NodeServerClient: require('./lib/Structures/NodeServerClient'),
+	NodeSocket: require('./lib/Structures/NodeSocket'),
+	Queue: require('./lib/Structures/Queue'),
+	SocketHandler: require('./lib/Structures/Base/SocketHandler')
+};

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2,6 +2,7 @@ import veza from './index.js';
 
 export const { Base } = veza;
 export const { Node } = veza;
+export const { NodeMessage } = veza;
 export const { NodeServer } = veza;
 export const { NodeServerClient } = veza;
 export const { NodeSocket } = veza;

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,1 +1,9 @@
-export { default as Node } from './lib/Node';
+import veza from './index.js';
+
+export const { Base } = veza;
+export const { Node } = veza;
+export const { NodeServer } = veza;
+export const { NodeServerClient } = veza;
+export const { NodeSocket } = veza;
+export const { Queue } = veza;
+export const { SocketHandler } = veza;

--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -458,12 +458,6 @@ module.exports = Node;
  * @param {net.Socket} socket The destroyed socket
  */
 /**
- * Emitted when the connection to a Socket has been destroyed.
- * @event Node#destroy
- * @param {string} name The label name of the socket
- * @param {net.Socket} socket The destroyed socket
- */
-/**
  * Emitted when a socket connects to the Node's server.
  * @event Node#connection
  * @param {string} socket The label name of the socket

--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -6,6 +6,7 @@ const kPing = Symbol('IPC-Ping');
 const kIdentify = Symbol('IPC-Identify');
 
 const bufferNull = Buffer.from('null');
+const bufferEOL = Buffer.from(require('os').EOL);
 const noop = () => { }; // eslint-disable-line no-empty-function
 
 class Node extends EventEmitter {
@@ -160,7 +161,6 @@ class Node extends EventEmitter {
 				const id = Node.createID();
 				const message = Node._packMessage(id, data, receptive);
 				socket.write(message);
-				socket.write('\n');
 
 				if (!receptive) return resolve(undefined);
 
@@ -301,7 +301,6 @@ class Node extends EventEmitter {
 			receptive,
 			reply: receptive ? (content) => {
 				socket.write(Node._packMessage(id, content, false));
-				socket.write('\n');
 			} : noop
 		}, { id: { value: id } }));
 		this.emit('message', message);
@@ -365,7 +364,7 @@ class Node extends EventEmitter {
 	static _packMessage(id, message, receptive = true) {
 		receptive = message === kPing || message === kIdentify ? 0 : Number(receptive);
 		const [type, buffer] = Node._getMessageDetails(message);
-		return Buffer.concat([Buffer.from(`${id} ${type} ${receptive} ${buffer.length.toString(36)} | `), buffer]);
+		return Buffer.concat([Buffer.from(`${id} ${type} ${receptive} ${buffer.length.toString(36)} | `), buffer, bufferEOL]);
 	}
 
 	/**

--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -61,9 +61,7 @@ class Node extends EventEmitter {
 	 * Send a message to a connected socket
 	 * @param {string} name The label name of the socket to send the message to
 	 * @param {*} data The data to send to the socket
-	 * @param {Object} [options={}] The options for this broadcast
-	 * @param {boolean} [options.receptive] Whether this message should wait for a response or not
-	 * @param {number} [options.timeout] The timeout, Infinity or -1 for no timeout
+	 * @param {SendOptions} [options={}] The options for this message
 	 * @returns {Promise<*>}
 	 */
 	sendTo(name, data, options) {
@@ -100,9 +98,7 @@ class Node extends EventEmitter {
 	/**
 	 * Broadcast a message to all connected sockets from this server
 	 * @param {*} data The data to send to other sockets
-	 * @param {Object} [options={}] The options for this broadcast
-	 * @param {boolean} [options.receptive] Whether this broadcast should wait for responses or not
-	 * @param {RegExp} [options.filter] The filter for the broadcast
+	 * @param {BroadcastOptions} [options={}] The options for this broadcast
 	 * @returns {Promise<Array<*>>}
 	 */
 	broadcast(data, options) {

--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -1,13 +1,6 @@
 const { EventEmitter } = require('events');
-const { Socket, Server } = require('net');
-
-const kSeparatorHeader = '|'.charCodeAt(0);
-const kPing = Symbol('IPC-Ping');
-const kIdentify = Symbol('IPC-Identify');
-
-const bufferNull = Buffer.from('\0');
-const bufferEOL = Buffer.from(require('os').EOL);
-const noop = () => { }; // eslint-disable-line no-empty-function
+const NodeSocket = require('./Structures/NodeSocket');
+const NodeServer = require('./Structures/NodeServer');
 
 class Node extends EventEmitter {
 
@@ -15,21 +8,6 @@ class Node extends EventEmitter {
 	 * @typedef {Object} NodeOptions
 	 * @property {number} [maxRetries = Infinity]
 	 * @property {number} [retryTime = 200]
-	 */
-
-	/**
-	 * @typedef {Object} NodeSocket
-	 * @property {string} name The label name for the socket
-	 * @property {Socket} [socket] The socket itself
-	 * @property {number} retriesRemaining The remaining reconnection retries
-	 */
-
-	/**
-	 * @typedef {Object} QueueEntry
-	 * @property {Socket} socket The socket the message is being sent to
-	 * @property {Function} resolve The resolve function
-	 * @property {Function} reject The reject function
-	 * @private
 	 */
 
 	/**
@@ -60,422 +38,89 @@ class Node extends EventEmitter {
 		this.retryTime = retryTime;
 
 		Object.defineProperties(this, {
-			_queue: { value: null, writable: true },
-			_remainingBuffer: { value: null, writable: true },
-			clients: { value: null, writable: true },
 			server: { value: null, writable: true },
 			servers: { value: null, writable: true }
 		});
 
 		/**
 		 * The server for this Node, if serving
-		 * @type {?Server}
+		 * @type {?NodeServer}
 		 * @private
 		 */
 		this.server = null;
 
 		/**
-		 * The sockets connected to this Node
+		 * The servers this Node is connected to
 		 * @type {Map<string, NodeSocket>}
 		 * @private
 		 */
-		this.clients = new Map();
-
-		/**
-		 * The servers this Node is connected to
-		 * @type {Map<string, Socket>}
-		 * @private
-		 */
 		this.servers = new Map();
-
-		/**
-		 * The queue for this Node
-		 * @type {Map<string, QueueEntry>}
-		 * @private
-		 */
-		this._queue = new Map();
-
-		/**
-		 * @type {?Buffer}
-		 * @private
-		 */
-		this._remainingBuffer = null;
-	}
-
-	/**
-	 * Create a server for this Node instance.
-	 * @param {...*} options The options to pass to net.Server#listen
-	 * @returns {this}
-	 */
-	serve(...options) {
-		if (this.server) throw new Error('There is already a server.');
-		this.server = new Server()
-			.on('connection', (socket) => {
-				let socketName = null;
-				socket
-					.on('error', (error) => {
-						// If the socket disconnected, the error is an ECONNRESET, perform cleanup
-						// @ts-ignore
-						if (error.code === 'ECONNRESET')
-							this._destroySocket(socketName, socket, true);
-						else
-							this.emit('error', error);
-					})
-					.on('data', (data) => this._onDataMessage(socketName, socket, data))
-					.on('close', () => {
-						// Cleanup
-						this._destroySocket(socketName, socket, true);
-					});
-				this.sendTo(socket, kIdentify).then(sName => {
-					socketName = sName;
-					this.servers.set(socketName, socket);
-					this.emit('connection', socketName, socket);
-				});
-			})
-			.on('close', () => {
-				this.server.removeAllListeners();
-				this.server = null;
-
-				for (const socket of this.servers.values()) socket.destroy();
-				this.emit('close');
-
-				if (this._queue.size) {
-					const rejectError = new Error('Server has been disconnected.');
-					for (const element of this._queue.values()) element.reject(rejectError);
-				}
-			})
-			.on('error', this.emit.bind(this, 'error'))
-			.on('listening', this.emit.bind(this, 'listening'));
-		this.server.listen(...options);
-		return this;
-	}
-
-	/**
-	 * Broadcast a message to all connected sockets from this server
-	 * @param {*} data The data to send to other sockets
-	 * @param {boolean} [receptive] Whether this broadcast should wait for responses or not
-	 * @returns {Promise<Array<*>>}
-	 */
-	broadcast(data, receptive) {
-		return Promise.all([...this.servers.values()].map(socket => this.sendTo(socket, data, receptive)));
 	}
 
 	/**
 	 * Send a message to a connected socket
-	 * @param {string|Socket} name The label name of the socket to send the message to
+	 * @param {string} name The label name of the socket to send the message to
 	 * @param {*} data The data to send to the socket
-	 * @param {boolean} receptive Whether this message should wait for a response or not
+	 * @param {boolean} [receptive = true] Whether this message should wait for a response or not
 	 * @returns {Promise<*>}
 	 */
-	sendTo(name, data, receptive = true) {
-		const socket = this._getSocket(name);
-		if (!socket) return Promise.reject(new Error('Failed to send to the socket.'));
-		if (!socket.writable) return Promise.reject(new Error('The Socket is not writable.'));
-
-		return new Promise((resolve, reject) => {
-			try {
-				const id = Node.createID();
-				const message = Node._packMessage(id, data, receptive);
-				socket.write(message);
-
-				if (!receptive) return resolve(undefined);
-
-				const send = (fn, response) => {
-					this._queue.delete(id);
-					return fn(response);
-				};
-				return this._queue.set(id, { socket, resolve: send.bind(null, resolve), reject: send.bind(null, reject) });
-			} catch (error) {
-				return reject(error);
-			}
-		});
-	}
-
-	/**
-	 * Measure the latency with other websockets
-	 * @param {string} name The label name of the socket to measure latency with
-	 * @returns {Promise<number>}
-	 */
-	pingTo(name) {
-		const now = Date.now();
-		return this.sendTo(name, kPing).then(future => future - now);
+	sendTo(name, data, receptive) {
+		const socket = this.servers.get(name);
+		if (!socket) return Promise.reject(new Error(`The socket ${name} is not available or not connected to this Node.`));
+		return socket.send(data, receptive);
 	}
 
 	/**
 	 * Connect to a socket
 	 * @param {string} name The label name for the socket
 	 * @param {...*} options The options to pass to connect
-	 * @returns {Promise<Socket>}
+	 * @returns {Promise<NodeSocket>}
 	 */
 	connectTo(name, ...options) {
-		if (this.clients.has(name)) return Promise.reject(new Error('There is already a socket.'));
-		const node = Object.defineProperties({}, {
-			name: { value: name, enumerable: true },
-			socket: { value: null, writable: true, enumerable: true },
-			retriesRemaining: { value: this.maxRetries, writable: true, enumerable: true },
-			_reconnectionTimeout: { value: null, writable: true }
-		});
+		if (this.servers.has(name)) return Promise.reject(new Error('There is already a socket.'));
+		const client = new NodeSocket(this, name);
+		this.servers.set(name, client);
 
-		return new Promise((resolve, reject) => {
-			node.socket = new Socket()
-				.on('connect', () => {
-					node.retriesRemaining = this.maxRetries;
-					if (node._reconnectionTimeout) clearTimeout(node._reconnectionTimeout);
-					this.emit('connect', name, node.socket);
-					resolve(node.socket);
-				})
-				.on('close', () => {
-					this.emit('disconnect', name, node.socket);
-					node._reconnectionTimeout = setTimeout(() => {
-						if (--node.retriesRemaining <= 0) {
-							this._destroySocket(name, node.socket, false);
-							reject(node.socket);
-						} else {
-							node.socket.connect(...options);
-						}
-					}, this.retryTime);
-				})
-				.on('error', this.emit.bind(this, 'error'))
-				.on('data', data => this._onDataMessage(name, node.socket, data));
-
-			this.clients.set(name, node);
-
-			// Set enconding and connect
-			node.socket.connect(...options);
-		});
+		return client.connect(...options);
 	}
 
 	/**
 	 * Disconnect from a socket, this will also reject all messages
 	 * @param {string} name The label name of the socket to disconnect
+	 * @returns {Promise<boolean>}
 	 */
 	disconnectFrom(name) {
-		const nodeSocket = this.clients.get(name);
-		if (!nodeSocket) throw new Error(`The socket ${name} is not connected to this one.`);
-		this._destroySocket(name, nodeSocket.socket, false);
+		const client = this.servers.get(name);
+		if (!client) return Promise.reject(new Error(`The socket ${name} is not connected to this one.`));
+		return Promise.resolve(client.disconnect());
 	}
 
 	/**
-	 * Resolves a socket
-	 * @param {string|Socket} name Resolves a socket
-	 * @returns {Socket}
+	 * Broadcast a message to all connected sockets from this server
+	 * @param {*} data The data to send to other sockets
+	 * @param {Object} [options={}] The options for this broadcast
+	 * @param {boolean} [options.receptive] Whether this broadcast should wait for responses or not
+	 * @param {RegExp} [options.filter] The filter for the broadcast
+	 * @returns {Promise<Array<*>>}
 	 */
-	_getSocket(name) {
-		if (name instanceof Socket) return name;
-		return (sk => sk ? sk.socket : null)(this.clients.get(name)) || this.servers.get(name) || null;
+	broadcast(data, options) {
+		return this.server ? this.server.broadcast(data, options) : Promise.resolve([]);
 	}
 
 	/**
-	 * Destroy a socket and perform all cleanup
-	 * @param {string} socketName The label name of the socket to destroy
-	 * @param {Socket} socket The Socket to destroy
-	 * @param {boolean} server Whether the destroy belongs to the Node's server or not
-	 * @private
+	 * Create a server for this Node instance.
+	 * @param {...*} options The options to pass to net.Server#listen
+	 * @returns {Promise<this>}
 	 */
-	_destroySocket(socketName, socket, server) {
-		socket.destroy();
-		socket.removeAllListeners();
+	serve(...options) {
+		if (this.server) throw new Error('There is already a server running.');
 
-		if (this._queue.size) {
-			const rejectError = new Error('Socket has been disconnected.');
-			for (const element of this._queue.values()) if (element.socket === socket) element.reject(rejectError);
-		}
-
-		if (server) {
-			this.servers.delete(socketName);
-			this.emit('socketClose', socketName);
-		} else {
-			this.clients.delete(socketName);
-			this.emit('destroy', socketName, socket);
-		}
-	}
-
-	/**
-	 * Parse the message
-	 * @param {string} name The label name of the socket
-	 * @param {Socket} socket The Socket that sent this message
-	 * @param {Buffer} buffer The buffer received
-	 * @private
-	 */
-	_onDataMessage(name, socket, buffer) {
-		this.emit('raw', name, socket, buffer);
-		this._unPackMessage(name, socket, buffer);
-	}
-
-	/**
-	 * Handle a parsed message
-	 * @param {string} name The label name of the socket
-	 * @param {Socket} socket The Socket that sent this message
-	 * @param {Object<string, *>} parsedData The parsed message data
-	 */
-	_handleMessage(name, socket, { id, receptive, data }) {
-		if (this._queue.has(id)) {
-			this._queue.get(id).resolve(data);
-			return;
-		}
-		if (data === kPing) {
-			socket.write(Node._packMessage(id, Date.now(), false));
-			return;
-		}
-		if (data === kIdentify) {
-			socket.write(Node._packMessage(id, this.name, false));
-			return;
-		}
-		const message = Object.freeze(Object.defineProperties({
-			data,
-			from: name,
-			receptive,
-			reply: receptive ? (content) => {
-				socket.write(Node._packMessage(id, content, false));
-			} : noop
-		}, { id: { value: id } }));
-		this.emit('message', message);
-	}
-
-	/**
-	 * Unpack a buffer message for usage
-	 * @param {string} name The label name of the socket
-	 * @param {Socket} socket The Socket that sent this message
-	 * @param {Buffer} buffer The buffer to unpack
-	 * @private
-	 */
-	_unPackMessage(name, socket, buffer) {
-		if (this._remainingBuffer) {
-			buffer = Buffer.concat([this._remainingBuffer, buffer]);
-			this._remainingBuffer = null;
-		}
-
-		while (buffer.length) {
-			const headerSeparatorIndex = buffer.indexOf(kSeparatorHeader);
-			// If the header separator was not found, it may be due to an impartial message
-			if (headerSeparatorIndex === -1) {
-				this._remainingBuffer = buffer;
-				break;
-			}
-
-			const [id, type, _receptive, bodyLength] = buffer.toString('utf8', 0, headerSeparatorIndex - 1).split(' ').map(value => value.trim());
-			if (!(type in R_MESSAGE_TYPES))
-				throw new Error(`Failed to unpack message. Got type ${type}, expected an integer between 0 and 7.`);
-
-			const startBodyIndex = headerSeparatorIndex + 2;
-			const endBodyIndex = startBodyIndex + parseInt(bodyLength, 36);
-			// If the body's length is not enough long, the Socket may have cut the message in half
-			if (endBodyIndex > buffer.length) {
-				this._remainingBuffer = buffer;
-				break;
-			}
-			const body = buffer.slice(startBodyIndex, endBodyIndex);
-
-			const pType = R_MESSAGE_TYPES[type];
-			const receptive = _receptive === '1';
-			const data = this._readMessage(body, pType);
-
-			this._handleMessage(name, socket, { id, receptive, data });
-			buffer = buffer.slice(endBodyIndex + 1);
-		}
-	}
-
-	_readMessage(body, type) {
-		if (type === 'PING') return kPing;
-		if (type === 'IDENTIFY') return kIdentify;
-		if (type === 'NULL') return null;
-		if (type === 'UNDEFINED') return undefined;
-		if (type === 'BUFFER') return body;
-
-		const bodyString = body.toString('utf8');
-		if (type === 'STRING') return bodyString;
-		if (type === 'BOOLEAN') return bodyString === '1';
-		if (type === 'SYMBOL') return Symbol.for(bodyString);
-		if (type === 'NUMBER') return Number(bodyString);
-		if (type === 'OBJECT') return JSON.parse(bodyString);
-		if (type === 'SET') return new Set(JSON.parse(bodyString));
-		if (type === 'MAP') return new Map(JSON.parse(bodyString));
-		if (type === 'BIGINT') return toBigInt(bodyString);
-
-		return body;
-	}
-
-	/**
-	 * Pack a message into a buffer for usage in other sockets
-	 * @param {string} id The id of the message to pack
-	 * @param {*} message The message to send
-	 * @param {boolean} receptive Whether this message requires a response or not
-	 * @returns {Buffer}
-	 * @private
-	 */
-	static _packMessage(id, message, receptive = true) {
-		const recflag = message === kPing || message === kIdentify ? 0 : Number(receptive);
-		const [type, buffer] = Node._getMessageDetails(message);
-		// @ts-ignore
-		return Buffer.concat([Buffer.from(`${id} ${type} ${recflag} ${buffer.length.toString(36)} | `), buffer, bufferEOL]);
-	}
-
-	/**
-	 * Get the message details
-	 * @param {*} message The message to convert
-	 * @returns {Array<number | Buffer>}
-	 */
-	static _getMessageDetails(message) {
-		if (message === kPing) return [S_MESSAGE_TYPES.PING, Buffer.from(Date.now().toString())];
-		if (message === kIdentify) return [S_MESSAGE_TYPES.IDENTIFY, bufferNull];
-
-		switch (typeof message) {
-			// @ts-ignore
-			case 'bigint': return [S_MESSAGE_TYPES.BIGINT, Buffer.from(message.toString())];
-			case 'undefined': return [S_MESSAGE_TYPES.UNDEFINED, bufferNull];
-			case 'string': return [S_MESSAGE_TYPES.STRING, Buffer.from(message)];
-			case 'number': return [S_MESSAGE_TYPES.NUMBER, Buffer.from(message.toString())];
-			case 'boolean': return [S_MESSAGE_TYPES.BOOLEAN, Buffer.from(message ? '1' : '0')];
-			case 'symbol': return [S_MESSAGE_TYPES.SYMBOL, Buffer.from(message.toString().slice(7, -1))];
-			case 'object': {
-				if (message === null) return [S_MESSAGE_TYPES.NULL, bufferNull];
-				if (message instanceof Set) return [S_MESSAGE_TYPES.SET, Buffer.from(JSON.stringify([...message]))];
-				if (message instanceof Map) return [S_MESSAGE_TYPES.MAP, Buffer.from(JSON.stringify([...message]))];
-				if (Buffer.isBuffer(message)) return [S_MESSAGE_TYPES.BUFFER, message];
-				return [S_MESSAGE_TYPES.OBJECT, Buffer.from(JSON.stringify(message))];
-			}
-			default:
-				return [S_MESSAGE_TYPES.STRING, Buffer.from(String(message))];
-		}
-	}
-
-	/**
-	 * Create an ID for a message
-	 * @returns {string}
-	 * @private
-	 */
-	static createID() {
-		i = i < 46656 ? i + 1 : 0;
-		return Date.now().toString(36) + i.toString(36);
+		this.server = new NodeServer(this);
+		return this.server.connect(...options)
+			.then(() => this);
 	}
 
 }
-
-// @ts-ignore
-const toBigInt = typeof BigInt === 'function' ? BigInt : Number;
-
-const S_MESSAGE_TYPES = Object.freeze({
-	NULL: 0,
-	STRING: 1,
-	NUMBER: 2,
-	SET: 3,
-	MAP: 4,
-	BUFFER: 5,
-	OBJECT: 6,
-	PING: 7,
-	IDENTIFY: 8,
-	BOOLEAN: 9,
-	UNDEFINED: 10,
-	SYMBOL: 11,
-	BIGINT: 12
-});
-
-// @ts-ignore
-const R_MESSAGE_TYPES = Object.assign({}, ...Object.entries(S_MESSAGE_TYPES)
-	.map(([key, value]) => ({ [value]: key }))
-);
-
-let i = 0;
 
 module.exports = Node;
 
@@ -488,49 +133,54 @@ module.exports = Node;
  */
 
 /**
- * Emitted on a successful connection to a Socket.
- * @event Node#connect
- * @param {string} name The label name of the socket
- * @param {net.Socket} socket The connected socket
+ * Emitted on a successful connection to a Socket
+ * @event Node#client.connect
+ * @param {NodeSocket | NodeServerClient} client The client that manages the socket
  */
 /**
- * Emitted on a disconnection with a Socket.
- * @event Node#disconnect
- * @param {string} name The label name of the socket
- * @param {net.Socket} socket The disconnected socket
+ * Emitted on a a Socket destroy
+ * @event Node#client.destroy
+ * @param {NodeSocket | NodeServerClient} client The client that manages the socket
  */
 /**
- * Emitted when the connection to a Socket has been destroyed.
- * @event Node#destroy
- * @param {string} name The label name of the socket
- * @param {net.Socket} socket The destroyed socket
+ * Emitted on a successful disconnection from a Socket
+ * @event Node#client.disconnect
+ * @param {NodeSocket | NodeServerClient} client The client that manages the socket
  */
 /**
- * Emitted when a socket connects to the Node's server.
- * @event Node#connection
- * @param {string} socket The label name of the socket
- * @param {net.Socket} socket The socket that connected to the server
+ * Emitted on a successful identification from a Socket
+ * @event Node#client.identify
+ * @param {NodeServerClient} client The client that manages the socket
  */
 /**
- * Emitted when the Node's server closes.
- * @event Node#close
+ * Emitted when a Socket is ready for usage
+ * @event Node#client.ready
+ * @param {NodeSocket | NodeServerClient} client The client that manages the socket
  */
 /**
- * Emitted when a socket connected to the server closes.
- * @event Node#socketClose
- * @param {string} name The label name of the socket that closed
- */
-/**
- * Emitted when the Node's server is ready.
- * @event Node#listening
- */
-/**
- * Emitted when any of the connected sockets error.
+ * Emitted when a node emits an error
  * @event Node#error
- * @param {Error} error The emitted error
+ * @param {Error} error The omitted error
+ * @param {NodeServer | NodeServerClient | NodeSocket} node The client that manages the socket
  */
 /**
- * Emitted when a Socket has sent a message to this Node.
+ * Emitted when a node receives a message
  * @event Node#message
- * @param {NodeMessage} message The received message
+ * @param {NodeMessage} message The message received
+ */
+/**
+ * Emitted when a node receives a message
+ * @event Node#raw
+ * @param {NodeSocket | NodeServerClient} client The client that manages the socket
+ * @param {Buffer} buffer The raw data received from the socket
+ */
+/**
+ * Emitted when a server destroys
+ * @event Node#server.destroy
+ * @param {ServerNode} server The client that manages the socket
+ */
+/**
+ * Emitted when a server is ready
+ * @event Node#server.ready
+ * @param {ServerNode} server The client that manages the socket
  */

--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -61,13 +61,15 @@ class Node extends EventEmitter {
 	 * Send a message to a connected socket
 	 * @param {string} name The label name of the socket to send the message to
 	 * @param {*} data The data to send to the socket
-	 * @param {boolean} [receptive = true] Whether this message should wait for a response or not
+	 * @param {Object} [options={}] The options for this broadcast
+	 * @param {boolean} [options.receptive] Whether this message should wait for a response or not
+	 * @param {number} [options.timeout] The timeout, Infinity or -1 for no timeout
 	 * @returns {Promise<*>}
 	 */
-	sendTo(name, data, receptive) {
+	sendTo(name, data, options) {
 		const socket = this.servers.get(name);
 		if (!socket) return Promise.reject(new Error(`The socket ${name} is not available or not connected to this Node.`));
-		return socket.send(data, receptive);
+		return socket.send(data, options);
 	}
 
 	/**
@@ -123,14 +125,6 @@ class Node extends EventEmitter {
 }
 
 module.exports = Node;
-
-/**
- * @typedef {Object} NodeMessage
- * @property {string} id The id of this message
- * @property {*} data The received data from the socket
- * @property {string} from The label name of the socket that sent this message
- * @property {boolean} receptive Whether this message can accept responses or not
- */
 
 /**
  * Emitted on a successful connection to a Socket

--- a/src/lib/Structures/Base/Base.js
+++ b/src/lib/Structures/Base/Base.js
@@ -1,0 +1,20 @@
+class Base {
+
+	constructor(node, name = null) {
+		Object.defineProperty(this, 'node', { value: null, writable: true });
+		/**
+		 * The Node instance that manages this
+		 * @type {Node}
+		 */
+		this.node = node;
+
+		/**
+		 * The name of this client
+		 * @type {string}
+		 */
+		this.name = name;
+	}
+
+}
+
+module.exports = Base;

--- a/src/lib/Structures/Base/SocketHandler.js
+++ b/src/lib/Structures/Base/SocketHandler.js
@@ -27,9 +27,7 @@ class SocketHandler extends Base {
 	/**
 	 * Send a message to a connected socket
 	 * @param {*} data The data to send to the socket
-	 * @param {Object} [options={}] The options for this broadcast
-	 * @param {boolean} [options.receptive] Whether this message should wait for a response or not
-	 * @param {number} [options.timeout] The timeout, Infinity or -1 for no timeout
+	 * @param {SendOptions} [options={}] The options for this message
 	 * @returns {Promise<*>}
 	 */
 	send(data, { receptive = true, timeout = Infinity } = {}) {

--- a/src/lib/Structures/Base/SocketHandler.js
+++ b/src/lib/Structures/Base/SocketHandler.js
@@ -1,9 +1,9 @@
 const { kPing, kIdentify, STATUS } = require('../../Util/Constants');
 const { _packMessage } = require('../../Util/Transform');
 const { createID } = require('../../Util/Header');
+const NodeMessage = require('../NodeMessage');
 const Queue = require('../Queue');
 const Base = require('./Base');
-const noop = () => { }; // eslint-disable-line no-empty-function
 
 class SocketHandler extends Base {
 
@@ -144,14 +144,7 @@ class SocketHandler extends Base {
 			this.socket.write(_packMessage(id, this.name, false));
 			return null;
 		}
-		return Object.freeze(Object.defineProperties({
-			data,
-			from: this.name,
-			receptive,
-			reply: receptive ? (content) => {
-				this.socket.write(_packMessage(id, content, false));
-			} : noop
-		}, { id: { value: id } }));
+		return new NodeMessage(this, id, receptive, data).freeze();
 	}
 
 }

--- a/src/lib/Structures/Base/SocketHandler.js
+++ b/src/lib/Structures/Base/SocketHandler.js
@@ -1,0 +1,153 @@
+const { kPing, kIdentify, STATUS } = require('../../Util/Constants');
+const { _packMessage } = require('../../Util/Transform');
+const { createID } = require('../../Util/Header');
+const Queue = require('../Queue');
+const Base = require('./Base');
+const noop = () => { }; // eslint-disable-line no-empty-function
+
+class SocketHandler extends Base {
+
+	constructor(node, name, socket = null) {
+		super(node, name);
+		Object.defineProperties(this, {
+			socket: { value: null, writable: true },
+			queue: { value: null, writable: true }
+		});
+
+		this.socket = socket;
+		this.queue = new Queue(this);
+
+		/**
+		 * The status of this client
+		 * @type {number}
+		 */
+		this.status = STATUS.CONNECTING;
+	}
+
+	/**
+	 * Send a message to a connected socket
+	 * @param {*} data The data to send to the socket
+	 * @param {boolean} [receptive = true] Whether this message should wait for a response or not
+	 * @returns {Promise<*>}
+	 */
+	send(data, receptive = true) {
+		if (!this.socket) return Promise.reject(new Error('This NodeSocket is not connected to a socket.'));
+
+		return new Promise((resolve, reject) => {
+			const id = createID();
+			try {
+				const message = _packMessage(id, data, receptive);
+				this.socket.write(message);
+
+				if (!receptive) {
+					resolve(undefined);
+					return;
+				}
+
+				const send = (fn, response) => {
+					this.queue.delete(id);
+					return fn(response);
+				};
+				this.queue.set(id, {
+					resolve: send.bind(null, resolve),
+					reject: send.bind(null, reject)
+				});
+			} catch (error) {
+				const entry = this.queue.get(id);
+				if (entry) entry.reject(error);
+				else reject(error);
+			}
+		});
+	}
+
+	/**
+	 * Disconnect from the socket, this will also reject all messages
+	 * @returns {boolean}
+	 */
+	disconnect() {
+		if (!this.socket) return false;
+
+		this.socket.destroy();
+		this.socket.removeAllListeners();
+
+		if (this.queue.size) {
+			const rejectError = new Error('Socket has been disconnected.');
+			for (const element of this.queue.values()) element.reject(rejectError);
+		}
+
+		this.status = STATUS.DISCONNECTED;
+
+		return true;
+	}
+
+	/**
+	 * Measure the latency between the server and this client
+	 * @returns {Promise<number>}
+	 */
+	ping() {
+		const now = Date.now();
+		return this.send(kPing).then((future) => future - now);
+	}
+
+	/**
+	 * Add a new event listener on this client's socket
+	 * @param {string} event The event name
+	 * @param {Function} cb The callback to register
+	 * @returns {this}
+	 * @chainable
+	 */
+	on(event, cb) {
+		if (this.socket) this.socket.on(event, cb);
+		return this;
+	}
+
+	/**
+	 * Add a new event listener on this client's socket
+	 * @param {string} event The event name
+	 * @param {Function} cb The callback to register
+	 * @returns {this}
+	 * @chainable
+	 */
+	once(event, cb) {
+		if (this.socket) this.socket.once(event, cb);
+		return this;
+	}
+
+	/**
+	 * Remove an event listener on this client's socket
+	 * @param {string} event The event name
+	 * @param {Function} cb The callback to unregister
+	 * @returns {this}
+	 * @chainable
+	 */
+	off(event, cb) {
+		if (this.socket) this.socket.off(event, cb);
+		return this;
+	}
+
+	_handleMessage({ id, receptive, data }) {
+		if (this.queue.has(id)) {
+			this.queue.get(id).resolve(data);
+			return null;
+		}
+		if (data === kPing) {
+			this.socket.write(_packMessage(id, Date.now(), false));
+			return null;
+		}
+		if (data === kIdentify) {
+			this.socket.write(_packMessage(id, this.name, false));
+			return null;
+		}
+		return Object.freeze(Object.defineProperties({
+			data,
+			from: this.name,
+			receptive,
+			reply: receptive ? (content) => {
+				this.socket.write(_packMessage(id, content, false));
+			} : noop
+		}, { id: { value: id } }));
+	}
+
+}
+
+module.exports = SocketHandler;

--- a/src/lib/Structures/Base/SocketHandler.js
+++ b/src/lib/Structures/Base/SocketHandler.js
@@ -47,9 +47,9 @@ class SocketHandler extends Base {
 				}
 
 				const timer = timeout !== Infinity && timeout !== -1
-					? setTimeout(() => send(reject, new Error('TIMEOUT_ERROR'), true), timeout)
+					? setTimeout(() => send(reject, true, new Error('TIMEOUT_ERROR')), timeout)
 					: null;
-				const send = (fn, response, fromTimer) => {
+				const send = (fn, fromTimer, response) => {
 					if (timer && !fromTimer) clearTimeout(timer);
 					this.queue.delete(id);
 					return fn(response);

--- a/src/lib/Structures/NodeMessage.js
+++ b/src/lib/Structures/NodeMessage.js
@@ -1,0 +1,69 @@
+const { _packMessage } = require('../Util/Transform');
+
+class NodeMessage {
+
+	constructor(client, id, receptive, data) {
+		Object.defineProperties(this, {
+			client: { value: client },
+			id: { value: id }
+		});
+
+		/**
+		 * The client that received this message
+		 * @type {SocketHandler}
+		 * @name NodeMessage#client
+		 * @property
+		 */
+
+		/**
+		 * The id of this message
+		 * @type {string}
+		 * @name NodeMessage#id
+		 * @property
+		 */
+
+		/**
+		 * The data received from the socket
+		 * @type {*}
+		 */
+		this.data = data;
+
+		/**
+		 * Whether the message is receptive or not
+		 * @type {boolean}
+		 */
+		this.receptive = receptive;
+	}
+
+	/**
+	 * Reply to the socket
+	 * @param {*} content The content to send
+	 */
+	reply(content) {
+		if (this.receptive) this.client.socket.write(_packMessage(this.id, content, false));
+	}
+
+	toJSON() {
+		return {
+			id: this.id,
+			data: this.data,
+			receptive: this.receptive
+		};
+	}
+
+	toString() {
+		return `NodeMessage<${this.id}>`;
+	}
+
+	/**
+	 * Freeze the object
+	 * @returns {Readonly<this>}
+	 * @private
+	 */
+	freeze() {
+		return Object.freeze(this);
+	}
+
+}
+
+module.exports = NodeMessage;

--- a/src/lib/Structures/NodeServer.js
+++ b/src/lib/Structures/NodeServer.js
@@ -1,0 +1,153 @@
+const { Server, Socket } = require('net');
+const NodeServerClient = require('./NodeServerClient');
+const NodeSocket = require('./NodeSocket');
+
+class NodeServer {
+
+	constructor(node) {
+		Object.defineProperties(this, {
+			node: { value: null, writable: true },
+			server: { value: null, writable: true },
+			clients: { value: null, writable: true }
+		});
+
+		/**
+		 * The Node instance that manages this
+		 * @type {Node}
+		 */
+		this.node = node;
+		this.server = null;
+		this.clients = new Map();
+	}
+
+	/**
+	 * The name of this node
+	 * @type {string}
+	 */
+	get name() {
+		return this.node.name;
+	}
+
+	/**
+	 * Get a NodeSocket by its name or Socket
+	 * @param {string|Socket|NodeServerClient|NodeSocket} name The NodeSocket to get
+	 * @returns {NodeServerClient|NodeSocket}
+	 */
+	get(name) {
+		if (typeof name === 'string') return this.clients.get(name) || null;
+		if (name instanceof NodeServerClient || name instanceof NodeSocket) return name;
+		if (name instanceof Socket) {
+			for (const client of this.clients.values()) if (client.socket === name) return client;
+			return null;
+		}
+
+		throw new TypeError(`Expected a string or an instance of Socket`);
+	}
+
+	/**
+	 * Check if a NodeSocket exists by its name of Socket
+	 * @param {string|Socket|NodeServerClient|NodeSocket} name The NodeSocket to get
+	 * @returns {boolean}
+	 */
+	has(name) {
+		return Boolean(this.get(name));
+	}
+
+	/**
+	 * Broadcast a message to all connected sockets from this server
+	 * @param {*} data The data to send to other sockets
+	 * @param {Object} [options={}] The options for this broadcast
+	 * @param {boolean} [options.receptive] Whether this broadcast should wait for responses or not
+	 * @param {RegExp} [options.filter] The filter for the broadcast
+	 * @returns {Promise<Array<*>>}
+	 */
+	broadcast(data, { receptive, filter } = {}) {
+		if (!filter) return Promise.all([...this.clients.values()].map((socket) => this.sendTo(socket, data, receptive)));
+		if (!(filter instanceof RegExp)) throw new TypeError(`filter must be a RegExp instance.`);
+
+		const promises = [];
+		for (const [name, client] of this.clients) if (filter.test(name)) promises.push(client.send(data, receptive));
+		return Promise.all(promises);
+	}
+
+	/**
+	 * Send a message to a connected socket
+	 * @param {string|Socket|NodeSocket} name The label name of the socket to send the message to
+	 * @param {*} data The data to send to the socket
+	 * @param {boolean} receptive Whether this message should wait for a response or not
+	 * @returns {Promise<*>}
+	 */
+	sendTo(name, data, receptive = true) {
+		const nodeSocket = this.get(name);
+		if (!nodeSocket) return Promise.reject(new Error('Failed to send to the socket: It is not connected to this Node.'));
+		return nodeSocket.send(data, receptive);
+	}
+
+	/**
+	 * Create a server for this Node instance.
+	 * @param {...*} options The options to pass to net.Server#listen
+	 * @returns {Promise<void>}
+	 */
+	async connect(...options) {
+		if (this.server) throw new Error('There is already a server.');
+
+		this.server = new Server();
+		await new Promise((resolve, reject) => {
+			const onListening = () => resolve(cleanup(this));
+			const onClose = () => reject(cleanup(this));
+			const onError = (error) => reject(cleanup(error));
+			const cleanup = (value) => {
+				this.server.off('listening', onListening);
+				this.server.off('close', onClose);
+				this.server.off('error', onError);
+				return value;
+			};
+			this.server
+				.on('listening', onListening)
+				.on('close', onClose)
+				.on('error', onError);
+
+			this.server.listen(...options);
+		});
+
+		this.node.emit('server.ready', this);
+		this.server
+			.on('connection', this._onConnection.bind(this))
+			.on('error', this._onError.bind(this))
+			.on('close', this._onClose.bind(this));
+	}
+
+	/**
+	 * Disconnect the server and rejects all current messages
+	 * @returns {boolean}
+	 */
+	disconnect() {
+		if (!this.server) return false;
+
+		this.server.close();
+		this.server = null;
+		this.node.server = null;
+		this.node.emit('server.destroy', this);
+
+		const rejectError = new Error('Server has been disconnected.');
+		for (const socket of this.clients.values())
+			for (const element of socket.queue.values()) element.reject(rejectError);
+
+		return true;
+	}
+
+	_onConnection(socket) {
+		new NodeServerClient(this.node, this, socket).setup();
+	}
+
+	_onError(error) {
+		this.node.emit('error', error, this);
+	}
+
+	_onClose() {
+		this.disconnect();
+	}
+
+}
+
+module.exports = NodeServer;

--- a/src/lib/Structures/NodeServer.js
+++ b/src/lib/Structures/NodeServer.js
@@ -4,6 +4,17 @@ const NodeSocket = require('./NodeSocket');
 
 class NodeServer {
 
+	/**
+	 * @typedef {Object} SendOptions
+	 * @property {boolean} [receptive = false] Whether this broadcast should wait for responses or not
+	 * @property {number} [timeout = Infinity] The timeout, Infinity or -1 for no timeout
+	 */
+
+	/**
+	 * @typedef {SendOptions} BroadcastOptions
+	 * @property {RegExp} [filter] The filter for the broadcast
+	 */
+
 	constructor(node) {
 		Object.defineProperties(this, {
 			node: { value: null, writable: true },
@@ -56,10 +67,7 @@ class NodeServer {
 	/**
 	 * Broadcast a message to all connected sockets from this server
 	 * @param {*} data The data to send to other sockets
-	 * @param {Object} [options={}] The options for this broadcast
-	 * @param {boolean} [options.receptive] Whether this broadcast should wait for responses or not
-	 * @param {number} [options.timeout] The timeout, Infinity or -1 for no timeout
-	 * @param {RegExp} [options.filter] The filter for the broadcast
+	 * @param {BroadcastOptions} [options={}] The options for this broadcast
 	 * @returns {Promise<Array<*>>}
 	 */
 	broadcast(data, { receptive, timeout, filter } = {}) {
@@ -75,9 +83,7 @@ class NodeServer {
 	 * Send a message to a connected socket
 	 * @param {string|Socket|NodeSocket} name The label name of the socket to send the message to
 	 * @param {*} data The data to send to the socket
-	 * @param {Object} [options={}] The options for this broadcast
-	 * @param {boolean} [options.receptive] Whether this message should wait for a response or not
-	 * @param {number} [options.timeout] The timeout, Infinity or -1 for no timeout
+	 * @param {SendOptions} [options={}] The options for this message
 	 * @returns {Promise<*>}
 	 */
 	sendTo(name, data, options) {

--- a/src/lib/Structures/NodeServerClient.js
+++ b/src/lib/Structures/NodeServerClient.js
@@ -1,0 +1,65 @@
+const SocketHandler = require('./Base/SocketHandler');
+const { kIdentify, STATUS } = require('../Util/Constants');
+
+class NodeServerClient extends SocketHandler {
+
+	constructor(node, server, socket) {
+		super(node, null, socket);
+		this.server = server;
+	}
+
+	setup() {
+		this.socket
+			.on('data', this._onData.bind(this))
+			.on('error', this._onError.bind(this))
+			.on('close', this._onClose.bind(this));
+
+		this.send(kIdentify).then((sName) => {
+			this.status = STATUS.READY;
+			this.name = sName;
+			this.server.clients.set(this.name, this);
+			this.node.emit('client.identify', this);
+		}).catch(this.disconnect.bind(this));
+	}
+
+	/**
+	 * Disconnect from the socket, this will also reject all messages
+	 * @returns {boolean}
+	 */
+	disconnect() {
+		if (!super.disconnect()) return false;
+		if (this.name) {
+			this.server.clients.delete(this.name);
+			this.node.emit('client.destroy', this);
+		}
+
+		return true;
+	}
+
+	_onData(data) {
+		this.node.emit('raw', this, data);
+		for (const processed of this.queue.process(data)) {
+			const message = this._handleMessage(processed);
+			if (message === null) continue;
+			this.node.emit('message', message);
+		}
+	}
+
+	_onError(error) {
+		const { code } = error;
+		if (code === 'ECONNRESET' || code === 'ECONNREFUSED') {
+			if (this.status !== STATUS.DISCONNECTED) return;
+			this.status = STATUS.DISCONNECTED;
+			this.node.emit('client.disconnect', this);
+		} else {
+			this.node.emit('error', error, this);
+		}
+	}
+
+	_onClose() {
+		this.disconnect();
+	}
+
+}
+
+module.exports = NodeServerClient;

--- a/src/lib/Structures/NodeSocket.js
+++ b/src/lib/Structures/NodeSocket.js
@@ -1,0 +1,114 @@
+const SocketHandler = require('./Base/SocketHandler');
+const { STATUS } = require('../Util/Constants');
+const { Socket } = require('net');
+
+class NodeSocket extends SocketHandler {
+
+	constructor(node, name, socket = null) {
+		super(node, name, socket);
+		this.retriesRemaining = node.maxRetries;
+
+		Object.defineProperty(this, '_reconnectionTimeout', { writable: true });
+		this._reconnectionTimeout = null;
+	}
+
+	/**
+	 * Connect to the socket
+	 * @param {...*} options The options to pass to connect
+	 * @returns {Promise<NodeSocket>}
+	 */
+	async connect(...options) {
+		if (!this.socket) this.socket = new Socket();
+
+		await new Promise((resolve, reject) => {
+			const onConnect = () => resolve(cleanup(this));
+			const onClose = () => reject(cleanup(this));
+			const onError = (error) => reject(cleanup(error));
+			const cleanup = (value) => {
+				this.socket.off('connect', onConnect);
+				this.socket.off('close', onClose);
+				this.socket.off('error', onError);
+				return value;
+			};
+			this.socket
+				.on('connect', onConnect)
+				.on('close', onClose)
+				.on('error', onError);
+
+			// @ts-ignore
+			this.socket.connect(...options);
+		});
+
+		this.status = STATUS.READY;
+		this.node.emit('client.ready', this);
+		this.socket
+			.on('data', this._onData.bind(this))
+			.on('connect', this._onConnect.bind(this))
+			.on('close', this._onClose.bind(this, ...options))
+			.on('error', this._onError.bind(this));
+
+		return this;
+	}
+
+	/**
+	 * Disconnect from the socket, this will also reject all messages
+	 * @returns {boolean}
+	 */
+	disconnect() {
+		if (!super.disconnect()) return false;
+
+		if (this._reconnectionTimeout) {
+			clearTimeout(this._reconnectionTimeout);
+			this._reconnectionTimeout = null;
+		}
+
+		this.node.clients.delete(this.name);
+		this.node.emit('client.destroy', this);
+		return true;
+	}
+
+	_onData(data) {
+		this.node.emit('raw', this, data);
+		for (const processed of this.queue.process(data)) {
+			const message = this._handleMessage(processed);
+			if (message === null) continue;
+			this.node.emit('message', message);
+		}
+	}
+
+	_onConnect() {
+		this.retriesRemaining = this.node.maxRetries;
+		if (this._reconnectionTimeout) {
+			clearTimeout(this._reconnectionTimeout);
+			this._reconnectionTimeout = null;
+		}
+		this.node.emit('client.connect', this);
+	}
+
+	_onClose(...options) {
+		this.node.emit('client.disconnect', this);
+		this._reconnectionTimeout = setTimeout(() => {
+			if (this.retriesRemaining === 0) {
+				this.disconnect();
+			} else {
+				this.retriesRemaining--;
+				// @ts-ignore
+				this.socket.connect(...options);
+			}
+		}, this.node.retryTime);
+	}
+
+	_onError(error) {
+		const { code } = error;
+		if (code === 'ECONNRESET' || code === 'ECONNREFUSED') {
+			if (this.status !== STATUS.DISCONNECTED) return;
+			this.status = STATUS.DISCONNECTED;
+			this.node.emit('client.disconnect', this);
+		} else {
+			this.node.emit('error', error, this);
+		}
+	}
+
+}
+
+module.exports = NodeSocket;

--- a/src/lib/Structures/Queue.js
+++ b/src/lib/Structures/Queue.js
@@ -1,0 +1,149 @@
+const {
+	// Symbols
+	kPing, kIdentify,
+
+	// Constants
+	R_MESSAGE_TYPES,
+
+	// Helpers
+	toBigInt
+} = require('../Util/Constants');
+const { readHeader } = require('../Util/Header');
+const { inspect } = require('util');
+
+/**
+ * @typedef {Object} QueueEntry
+ * @property {Function} resolve The resolve function
+ * @property {Function} reject The reject function
+ * @private
+ */
+
+/**
+ * @extends {Map<string,QueueEntry>}
+ */
+class Queue extends Map {
+
+	constructor(nodeSocket) {
+		super();
+		this.nodeSocket = nodeSocket;
+		this._rest = null;
+	}
+
+	/**
+	 * The Node that manages this instance
+	 * @type {Node}
+	 */
+	get node() {
+		return this.nodeSocket.node;
+	}
+
+	/**
+	 * The name of the client that manages this instance
+	 * @type {string}
+	 */
+	get name() {
+		return this.nodeSocket.name;
+	}
+
+	/**
+	 * The socket contained in the client that manages this instance
+	 * @type {Socket}
+	 */
+	get socket() {
+		return this.nodeSocket.socket;
+	}
+
+	/**
+	 * @typedef {Object} QueueObject
+	 * @property {string} id The id of the message
+	 * @property {boolean} receptive Whether this message is receptive or not
+	 * @property {Buffer} data The data received from the socket
+	 * @private
+	 */
+
+	/**
+	 * Returns a new Iterator object that parses each value for this queue.
+	 * @name @@iterator
+	 * @method
+	 * @instance
+	 * @generator
+	 * @returns {Iterator<QueueObject>}
+	 * @memberof Queue
+	 */
+
+	*process(buffer) {
+		if (this._rest) {
+			buffer = Buffer.concat([this._rest, buffer]);
+			this._rest = null;
+		}
+
+		let bLength = buffer.byteLength;
+		while (bLength) {
+			// If the header separator was not found, it may be due to an impartial message
+			if (bLength <= 13) {
+				this._rest = buffer;
+				break;
+			}
+
+			const { id, type, receptive, length: bodyLength } = readHeader(buffer);
+			if (type > R_MESSAGE_TYPES.length)
+				throw new Error(`Failed to parse type, received ${type} from ${inspect(buffer)}`);
+
+			const endBodyIndex = 13 + bodyLength;
+			// If the body's length is not enough long, the Socket may have cut the message in half
+			if (endBodyIndex > bLength) {
+				this._rest = buffer;
+				break;
+			}
+			const body = buffer.slice(13, endBodyIndex);
+
+			const pType = R_MESSAGE_TYPES[type];
+			const data = this._readMessage(body, pType);
+
+			buffer = buffer.slice(endBodyIndex + 1);
+			bLength = buffer.byteLength;
+			yield { id, receptive, data };
+		}
+	}
+
+	/**
+	 * Flushes the queue
+	 */
+	flush() {
+		this._rest = null;
+	}
+
+	_readMessage(body, type) { // eslint-disable-line complexity
+		if (type === 'PING') return kPing;
+		if (type === 'IDENTIFY') return kIdentify;
+		if (type === 'NULL') return null;
+		if (type === 'UNDEFINED') return undefined;
+		if (type === 'BUFFER') return body;
+		if (type === 'BYTE') return body[0];
+
+		const bodyString = body.toString('utf8');
+		if (type === 'BOOLEAN') return bodyString === '1';
+		if (type === 'STRING') return bodyString;
+		if (type === 'NUMBER') return Number(bodyString);
+		if (type === 'BIGINT') return toBigInt(bodyString);
+		if (type === 'OBJECT') return JSON.parse(bodyString);
+		if (type === 'SYMBOL') return Symbol.for(bodyString);
+		if (type === 'MAP') return new Map(JSON.parse(bodyString));
+		if (type === 'SET') return new Set(JSON.parse(bodyString));
+		if (type === 'ARRAY_BUFFER') return new ArrayBuffer(JSON.parse(bodyString));
+		if (type === 'FLOAT32_ARRAY') return new Float32Array(JSON.parse(bodyString));
+		if (type === 'FLOAT64_ARRAY') return new Float64Array(JSON.parse(bodyString));
+		if (type === 'INT8_ARRAY') return new Int8Array(JSON.parse(bodyString));
+		if (type === 'INT16_ARRAY') return new Int16Array(JSON.parse(bodyString));
+		if (type === 'INT32_ARRAY') return new Int32Array(JSON.parse(bodyString));
+		if (type === 'UINT8_ARRAY') return new Uint8Array(JSON.parse(bodyString));
+		if (type === 'UINT8_CLAMPEDARRAY') return new Uint8ClampedArray(JSON.parse(bodyString));
+		if (type === 'UINT16_ARRAY') return new Uint16Array(JSON.parse(bodyString));
+		if (type === 'UINT32_ARRAY') return new Uint32Array(JSON.parse(bodyString));
+
+		return body;
+	}
+
+}
+
+module.exports = Queue;

--- a/src/lib/Util/Constants.js
+++ b/src/lib/Util/Constants.js
@@ -1,0 +1,47 @@
+module.exports = {
+	// Symbols
+	kPing: Symbol('IPC-Ping'),
+	kIdentify: Symbol('IPC-Identify'),
+
+	// Constants
+	S_MESSAGE_TYPES: Object.freeze({
+		BIGINT: 0,
+		BOOLEAN: 1,
+		BUFFER: 2,
+		BYTE: 3,
+		FLOAT32_ARRAY: 4,
+		FLOAT64_ARRAY: 5,
+		INT16_ARRAY: 6,
+		INT32_ARRAY: 7,
+		INT8_ARRAY: 8,
+		MAP: 9,
+		NULL: 10,
+		NUMBER: 11,
+		OBJECT: 12,
+		SET: 13,
+		STRING: 14,
+		SYMBOL: 15,
+		UINT16_ARRAY: 16,
+		UINT32_ARRAY: 17,
+		UINT8_ARRAY: 18,
+		UINT8_CLAMPEDARRAY: 19,
+		UNDEFINED: 20,
+		PING: 21,
+		IDENTIFY: 22
+	}),
+	R_MESSAGE_TYPES: null,
+	BUFFER_NULL: Buffer.from('\0'),
+	BUFFER_NL: Buffer.from('\n'),
+	STATUS: Object.freeze({
+		READY: 0,
+		CONNECTING: 1,
+		DISCONNECTED: 2
+	}),
+
+	// Helpers
+	// @ts-ignore
+	toBigInt: typeof BigInt === 'function' ? BigInt : Number
+};
+
+// @ts-ignore
+module.exports.R_MESSAGE_TYPES = Object.keys(module.exports.S_MESSAGE_TYPES);

--- a/src/lib/Util/Header.js
+++ b/src/lib/Util/Header.js
@@ -1,0 +1,43 @@
+function getBytes(number) {
+	const result = [];
+	while (number >= 1) {
+		result.unshift(Math.floor(number) % 0xFF);
+		number /= 0xFF;
+	}
+
+	return result;
+}
+
+function parseBytes(bytes) {
+	let number = 0;
+	let n = 1;
+	for (let i = bytes.length - 1; i >= 0; i--) {
+		number += bytes[i] * n;
+		n *= 0xFF;
+	}
+	return number;
+}
+
+function fill(bytes, length) {
+	if (bytes.length < length) for (let i = length - bytes.length; i > 0; i--) bytes.unshift(0);
+	return bytes;
+}
+
+function createHeader(id, type, receptive, length) {
+	return Buffer.concat([
+		Buffer.from(id, 'base64'),
+		Buffer.from([type, receptive ? 1 : 0, ...fill(getBytes(length), 4)])
+	]);
+}
+
+function readHeader(header) {
+	return { id: header.toString('base64', 0, 7), type: header[7], receptive: Boolean(header[8]), length: parseBytes(header.slice(9, 13)) };
+}
+
+let a = 0;
+function createID() {
+	a = a < 0xFFFF ? a + 1 : 0;
+	return Buffer.from(getBytes(Date.now()).concat(a)).toString('base64');
+}
+
+module.exports = Object.freeze({ createHeader, readHeader, createID });

--- a/src/lib/Util/Transform.js
+++ b/src/lib/Util/Transform.js
@@ -1,0 +1,74 @@
+const {
+	// Symbols
+	kPing, kIdentify,
+
+	// Constants
+	S_MESSAGE_TYPES, BUFFER_NULL, BUFFER_NL
+} = require('./Constants');
+
+const { createHeader } = require('./Header');
+
+/**
+ * Pack a message into a buffer for usage in other sockets
+ * @param {string} id The id of the message to pack
+ * @param {*} message The message to send
+ * @param {boolean} receptive Whether this message requires a response or not
+ * @returns {Buffer}
+ * @private
+ */
+function _packMessage(id, message, receptive = true) {
+	if (message === kPing || message === kIdentify) receptive = false;
+	const [type, buffer] = _getMessageDetails(message);
+	// @ts-ignore
+	return Buffer.concat([createHeader(id, type, receptive, buffer.byteLength), buffer, BUFFER_NL]);
+}
+
+/**
+ * Get the message details
+ * @param {*} message The message to convert
+ * @returns {Array<number | Buffer>}
+ */
+function _getMessageDetails(message) {
+	if (message === kPing) return [S_MESSAGE_TYPES.PING, Buffer.from(Date.now().toString())];
+	if (message === kIdentify) return [S_MESSAGE_TYPES.IDENTIFY, BUFFER_NULL];
+
+	switch (typeof message) {
+		// @ts-ignore
+		case 'bigint': return [S_MESSAGE_TYPES.BIGINT, Buffer.from(message.toString())];
+		case 'undefined': return [S_MESSAGE_TYPES.UNDEFINED, BUFFER_NULL];
+		case 'string': return [S_MESSAGE_TYPES.STRING, Buffer.from(message)];
+		case 'number': return message <= 0xFF
+			? [S_MESSAGE_TYPES.BYTE, Buffer.from(message)]
+			: [S_MESSAGE_TYPES.NUMBER, Buffer.from(message.toString())];
+		case 'boolean': return [S_MESSAGE_TYPES.BOOLEAN, Buffer.from(message ? '1' : '0')];
+		case 'symbol': return [S_MESSAGE_TYPES.SYMBOL, Buffer.from(message.toString().slice(7, -1))];
+		case 'object': {
+			if (message === null) return [S_MESSAGE_TYPES.NULL, BUFFER_NULL];
+			if (message.constructor === Object) return [S_MESSAGE_TYPES.OBJECT, Buffer.from(JSON.stringify(message))];
+			if (message instanceof Set) return [S_MESSAGE_TYPES.SET, Buffer.from(JSON.stringify([...message]))];
+			if (message instanceof Map) return [S_MESSAGE_TYPES.MAP, Buffer.from(JSON.stringify([...message]))];
+			if (Buffer.isBuffer(message)) return [S_MESSAGE_TYPES.BUFFER, message];
+			if ('buffer' in message && message.buffer instanceof ArrayBuffer) return [_getArrayType(message), Buffer.from(JSON.stringify([...message]))];
+			return [S_MESSAGE_TYPES.OBJECT, Buffer.from(JSON.stringify(message))];
+		}
+		default:
+			return [S_MESSAGE_TYPES.STRING, Buffer.from(String(message))];
+	}
+}
+
+function _getArrayType(array) {
+	switch (array.constructor) {
+		case Int8Array: return S_MESSAGE_TYPES.INT8_ARRAY;
+		case Int16Array: return S_MESSAGE_TYPES.INT16_ARRAY;
+		case Int32Array: return S_MESSAGE_TYPES.INT32_ARRAY;
+		case Uint8Array: return S_MESSAGE_TYPES.UINT8_ARRAY;
+		case Uint8ClampedArray: return S_MESSAGE_TYPES.UINT8_CLAMPEDARRAY;
+		case Uint16Array: return S_MESSAGE_TYPES.UINT16_ARRAY;
+		case Uint32Array: return S_MESSAGE_TYPES.UINT32_ARRAY;
+		case Float32Array: return S_MESSAGE_TYPES.FLOAT32_ARRAY;
+		case Float64Array: return S_MESSAGE_TYPES.FLOAT64_ARRAY;
+		default: return S_MESSAGE_TYPES.OBJECT;
+	}
+}
+
+module.exports = Object.freeze({ _packMessage, _getMessageDetails });

--- a/test/hello.js
+++ b/test/hello.js
@@ -4,12 +4,10 @@ const { Node } = require('../src/index');
 
 // eslint-disable-next-line no-unused-vars
 const node = new Node('hello')
-	.on('connection', (name) => {
-		console.log(`Connected to ${name}`);
-	})
-	.on('listening', console.log.bind(null, 'Listening'))
-	.on('message', message => {
-		console.log(`Received data:`, message);
+	.on('client.connect', (client) => console.log(`[IPC] Client Connected: ${client.name}`))
+	.on('server.ready', (server) => console.log(`[IPC] Client Ready: Named ${server.name}`))
+	.on('message', (message) => {
+		// console.log(`Received data:`, message.data);
 		// For World.js test
 		if (message.data === 'Hello') {
 			message.reply('world!');
@@ -20,6 +18,7 @@ const node = new Node('hello')
 			);
 		}
 	})
-	.on('error', console.error.bind(null, 'Error'))
-	.on('socketClose', console.log.bind(null, 'Closed Socket:'))
+	.on('error', (error, client) => console.error(`[IPC] Error from ${client.name}`, error))
+	.on('client.disconnect', (client) => console.log(`[IPC] Client Disconnected: ${client.name}`))
+	.on('client.destroy', (client) => console.log(`[IPC] Client Destroyed: ${client.name}`))
 	.serve(8001);

--- a/test/hello.js
+++ b/test/hello.js
@@ -22,4 +22,4 @@ const node = new Node('hello')
 	})
 	.on('error', console.error.bind(null, 'Error'))
 	.on('socketClose', console.log.bind(null, 'Closed Socket:'))
-	.serve('hello', 8001);
+	.serve(8001);

--- a/test/hello.js
+++ b/test/hello.js
@@ -5,6 +5,8 @@ const { Node } = require('../src/index');
 // eslint-disable-next-line no-unused-vars
 const node = new Node('hello')
 	.on('client.connect', (client) => console.log(`[IPC] Client Connected: ${client.name}`))
+	.on('client.disconnect', (client) => console.log(`[IPC] Client Disconnected: ${client.name}`))
+	.on('client.destroy', (client) => console.log(`[IPC] Client Destroyed: ${client.name}`))
 	.on('server.ready', (server) => console.log(`[IPC] Client Ready: Named ${server.name}`))
 	.on('message', (message) => {
 		// console.log(`Received data:`, message.data);
@@ -19,6 +21,4 @@ const node = new Node('hello')
 		}
 	})
 	.on('error', (error, client) => console.error(`[IPC] Error from ${client.name}`, error))
-	.on('client.disconnect', (client) => console.log(`[IPC] Client Disconnected: ${client.name}`))
-	.on('client.destroy', (client) => console.log(`[IPC] Client Destroyed: ${client.name}`))
 	.serve(8001);

--- a/test/interactive.js
+++ b/test/interactive.js
@@ -4,15 +4,18 @@
 const { Node } = require('../src/index');
 
 const node = new Node('interactive')
+	.on('error', (error, client) => console.error(`[IPC] Error from ${client.name}:`, error))
+	.on('client.disconnect', (client) => console.error(`[IPC] Disconnected from ${client.name}`))
+	.on('client.ready', (client) => console.log(`[IPC] Connected to: ${client.name}`))
 	.on('message', (message) => {
 		console.log(`Received data from ${message.from}:`, message);
 		if (message.data === 'Hello') {
 			message.reply('Interactive World Working!');
 			process.stdout.write('> ');
 		}
-	})
-	.on('error', console.error)
-	.on('connect', () => console.log('Connected!'));
+	});
+
+// Connect to hello
 node.connectTo('hello', 8001)
 	.catch(() => console.log('Disconnected!'));
 

--- a/test/interactive.js
+++ b/test/interactive.js
@@ -8,7 +8,7 @@ const node = new Node('interactive')
 	.on('client.disconnect', (client) => console.error(`[IPC] Disconnected from ${client.name}`))
 	.on('client.ready', (client) => console.log(`[IPC] Connected to: ${client.name}`))
 	.on('message', (message) => {
-		console.log(`Received data from ${message.from}:`, message);
+		console.log(`Received data from ${message.client.name}:`, message);
 		if (message.data === 'Hello') {
 			message.reply('Interactive World Working!');
 			process.stdout.write('> ');

--- a/test/interactive.js
+++ b/test/interactive.js
@@ -26,6 +26,6 @@ const rl = readline.createInterface({
 });
 
 rl.on('line', (line) => {
-	if (line) node.sendTo('hello', line, false);
+	if (line) node.sendTo('hello', line, { receptive: false });
 	process.stdout.write('> ');
 });

--- a/test/world.js
+++ b/test/world.js
@@ -3,13 +3,14 @@
 const { Node } = require('../src/index');
 
 const node = new Node('world')
-	.on('message', (message) => {
-		console.log(`Received data from ${message.from}:`, message);
-		if (message.data === 'Hello')
-			message.reply('world!');
-	})
-	.on('error', console.error)
-	.on('connect', () => console.log('Connected!'));
+	.on('error', (error, client) => console.error(`[IPC] Error from ${client.name}:`, error))
+	.on('client.disconnect', (client) => console.error(`[IPC] Disconnected from ${client.name}`))
+	.on('client.ready', (client) => {
+		console.log(`[IPC] Connected to: ${client.name}`);
+		client.send('Hello', { timeout: 5000 })
+			.then((result) => console.log(`[TEST] Hello ${result}`))
+			.catch((error) => console.error(`[TEST] Client send errored: ${error}`));
+	});
 
 node.connectTo('hello', 8001)
-	.catch(() => console.log('Disconnected!'));
+	.catch((error) => console.error('[IPC] Disconnected!', error));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es2018",
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"typings/index.d.ts"
+	]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,7 @@
 			true, "check-space"
 		],
 		"indent": [
-			true, "spaces"
+			true, "tabs"
 		],
 		"curly": false,
 		"class-name": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,60 @@
+{
+	"rules": {
+		"no-inferrable-types": [false],
+		"no-unused-expression": true,
+		"no-duplicate-variable": true,
+		"no-shadowed-variable": true,
+		"comment-format": [
+			true, "check-space"
+		],
+		"indent": [
+			true, "spaces"
+		],
+		"curly": false,
+		"class-name": true,
+		"semicolon": [true],
+		"triple-equals": true,
+		"eofline": true,
+		"no-bitwise": false,
+		"no-console": [false],
+		"member-access": [true, "check-accessor", "check-constructor"],
+		"no-consecutive-blank-lines": [true],
+		"no-parameter-properties": true,
+		"one-line": [
+			false
+		],
+		"variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
+		"interface-name": [true, "always-prefix"],
+		"no-conditional-assignment": true,
+		"use-isnan": true,
+		"no-trailing-whitespace": true,
+		"quotemark": [true, "single", "avoid-escape"],
+		"no-use-before-declare": false,
+		"whitespace": [true,
+			"check-branch",
+			"check-decl",
+			"check-operator",
+			"check-module",
+			"check-separator",
+			"check-type",
+			"check-typecast"
+		],
+		"typedef-whitespace": [
+			true,
+			{
+				"call-signature": "nospace",
+				"index-signature": "nospace",
+				"parameter": "nospace",
+				"property-declaration": "nospace",
+				"variable-declaration": "nospace"
+			},
+			{
+				"call-signature": "onespace",
+				"index-signature": "onespace",
+				"parameter": "onespace",
+				"property-declaration": "onespace",
+				"variable-declaration": "onespace"
+			}
+		]
+	}
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -76,28 +76,28 @@ declare module 'veza' {
 	}
 
 	export interface NodeOptions {
-		public maxRetries?: number;
-		public retryTime?: number;
+		maxRetries?: number;
+		retryTime?: number;
 	}
 
 	export interface NodeSocket {
-		public readonly name: string;
-		public socket: Socket | null;
-		public retriesRemaining: number;
-		private _reconnectionTimeout: NodeJS.Timer;
+		readonly name: string;
+		socket: Socket | null;
+		retriesRemaining: number;
+		_reconnectionTimeout: NodeJS.Timer;
 	}
 
-	export interface NodeMessage {
-		private readonly id: string;
-		public readonly data: any;
-		public readonly from: string;
-		public readonly receptive: boolean;
-		public reply(content: any): void;
-	}
+	export type NodeMessage = Readonly<{
+		id: string;
+		data: any;
+		from: string;
+		receptive: boolean;
+		reply(content: any): void;
+	}>;
 
 	interface QueueEntry {
-		public resolve(data: any): void;
-		public reject(data: any): void;
+		resolve(data: any): void;
+		reject(data: any): void;
 	}
 
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -19,8 +19,8 @@ declare module 'veza' {
 		public on(event: 'error', listener: (error: Error, node: NodeServer | NodeServerClient | NodeSocket) => void): this;
 		public on(event: 'message', listener: (message: NodeMessage) => void): this;
 		public on(event: 'raw', listener: (node: NodeServerClient | NodeSocket, buffer: Buffer) => void): this;
-		public on(event: 'server.destroy', listener: (server: ServerNode) => void): this;
-		public on(event: 'server.ready', listener: (server: ServerNode) => void): this;
+		public on(event: 'server.destroy', listener: (server: NodeServer) => void): this;
+		public on(event: 'server.ready', listener: (server: NodeServer) => void): this;
 		public on(event: string, listener: Function): this;
 
 		public once(event: 'client.connect', listener: (client: NodeSocket | NodeServerClient) => void): this;
@@ -31,8 +31,8 @@ declare module 'veza' {
 		public once(event: 'error', listener: (error: Error, node: NodeServer | NodeServerClient | NodeSocket) => void): this;
 		public once(event: 'message', listener: (message: NodeMessage) => void): this;
 		public once(event: 'raw', listener: (node: NodeServerClient | NodeSocket, buffer: Buffer) => void): this;
-		public once(event: 'server.destroy', listener: (server: ServerNode) => void): this;
-		public once(event: 'server.ready', listener: (server: ServerNode) => void): this;
+		public once(event: 'server.destroy', listener: (server: NodeServer) => void): this;
+		public once(event: 'server.ready', listener: (server: NodeServer) => void): this;
 		public once(event: string, listener: Function): this;
 
 		public off(event: 'client.connect', listener: (client: NodeSocket | NodeServerClient) => void): this;
@@ -43,8 +43,8 @@ declare module 'veza' {
 		public off(event: 'error', listener: (error: Error, node: NodeServer | NodeServerClient | NodeSocket) => void): this;
 		public off(event: 'message', listener: (message: NodeMessage) => void): this;
 		public off(event: 'raw', listener: (node: NodeServerClient | NodeSocket, buffer: Buffer) => void): this;
-		public off(event: 'server.destroy', listener: (server: ServerNode) => void): this;
-		public off(event: 'server.ready', listener: (server: ServerNode) => void): this;
+		public off(event: 'server.destroy', listener: (server: NodeServer) => void): this;
+		public off(event: 'server.ready', listener: (server: NodeServer) => void): this;
 		public off(event: string, listener: Function): this;
 
 		public broadcast<T = any>(data: any, options: BroadcastOptions): Promise<Array<T>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -168,6 +168,17 @@ declare module 'veza' {
 		private _onError(error: Error): void;
 	}
 
+	export class NodeMessage {
+		public readonly client: NodeSocket | NodeServerClient;
+		public readonly id: string;
+		public data: any;
+		public receptive: boolean;
+		public reply(content: any): void;
+		public toJSON(): { id: string, data: any, receptive: boolean };
+		public toString(): string;
+		private freeze(): Readonly<this>;
+	}
+
 	export class Queue extends Map<string, QueueEntry> {
 		constructor(nodeSocket: NodeSocket | NodeServerClient);
 		public nodeSocket: NodeSocket | NodeServerClient;
@@ -192,14 +203,6 @@ declare module 'veza' {
 		maxRetries?: number;
 		retryTime?: number;
 	}
-
-	type NodeMessage = Readonly<{
-		id: string;
-		data: any;
-		from: string;
-		receptive: boolean;
-		reply(content: any): void;
-	}>;
 
 	interface QueueEntry {
 		socket: Socket;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,94 +2,198 @@ declare module 'veza' {
 
 	import { EventEmitter } from 'events';
 	import { Server, Socket, ListenOptions, SocketConnectOpts } from 'net';
-	import { resolve } from 'dns';
 
 	export class Node extends EventEmitter {
 		public constructor(name: string, options?: NodeOptions);
+		public name: string;
 		public maxRetries: number;
 		public retryTime: number;
-		public server: Server | null;
-		public readonly name: string;
-		public readonly sockets: Map<string, NodeSocket>;
-		private _remainingBuffer: Buffer | null;
-		private readonly _queue: Map<string, QueueEntry>;
-		private readonly _serverNodes: Map<string, Socket>;
+		private server: NodeServer | null;
+		private servers: Map<string, NodeSocket>;
 
-		// Socket events
-		public on(event: 'connect', listener: (name: string, socket: Socket) => void): this;
-		public on(event: 'disconnect', listener: (name: string, socket: Socket) => void): this;
-		public on(event: 'destroy', listener: (name: string, socket: Socket) => void): this;
+		public on(event: 'client.connect', listener: (client: NodeSocket | NodeServerClient) => void): this;
+		public on(event: 'client.destroy', listener: (client: NodeSocket | NodeServerClient) => void): this;
+		public on(event: 'client.disconnect', listener: (client: NodeSocket | NodeServerClient) => void): this;
+		public on(event: 'client.identify', listener: (client: NodeServerClient) => void): this;
+		public on(event: 'client.ready', listener: (client: NodeSocket) => void): this;
+		public on(event: 'error', listener: (error: Error, node: NodeServer | NodeServerClient | NodeSocket) => void): this;
 		public on(event: 'message', listener: (message: NodeMessage) => void): this;
-
-		// Server events
-		public on(event: 'connection', listener: (socket: Socket) => void): this;
-		public on(event: 'close', listener: () => void): this;
-		public on(event: 'socketClose', listener: (name: string) => void): this;
-		public on(event: 'listening', listener: () => void): this;
-
-		// Generic events
-		public on(event: 'error', listener: (error: Error) => void): this;
-		public on(event: 'raw', listener: (name: string, socket: Socket, buffer: Buffer) => void): this;
+		public on(event: 'raw', listener: (node: NodeServerClient | NodeSocket, buffer: Buffer) => void): this;
+		public on(event: 'server.destroy', listener: (server: ServerNode) => void): this;
+		public on(event: 'server.ready', listener: (server: ServerNode) => void): this;
 		public on(event: string, listener: Function): this;
 
-		// Socket events
-		public once(event: 'connect', listener: (name: string, socket: Socket) => void): this;
-		public once(event: 'disconnect', listener: (name: string, socket: Socket) => void): this;
-		public once(event: 'destroy', listener: (name: string, socket: Socket) => void): this;
+		public once(event: 'client.connect', listener: (client: NodeSocket | NodeServerClient) => void): this;
+		public once(event: 'client.destroy', listener: (client: NodeSocket | NodeServerClient) => void): this;
+		public once(event: 'client.disconnect', listener: (client: NodeSocket | NodeServerClient) => void): this;
+		public once(event: 'client.identify', listener: (client: NodeServerClient) => void): this;
+		public once(event: 'client.ready', listener: (client: NodeSocket) => void): this;
+		public once(event: 'error', listener: (error: Error, node: NodeServer | NodeServerClient | NodeSocket) => void): this;
 		public once(event: 'message', listener: (message: NodeMessage) => void): this;
-
-		// Server events
-		public once(event: 'connection', listener: (name: string, socket: Socket) => void): this;
-		public once(event: 'close', listener: () => void): this;
-		public once(event: 'socketClose', listener: (name: string) => void): this;
-		public once(event: 'listening', listener: () => void): this;
-
-		// Generic events
-		public once(event: 'error', listener: (error: Error) => void): this;
-		public once(event: 'raw', listener: (name: string, socket: Socket, buffer: Buffer) => void): this;
+		public once(event: 'raw', listener: (node: NodeServerClient | NodeSocket, buffer: Buffer) => void): this;
+		public once(event: 'server.destroy', listener: (server: ServerNode) => void): this;
+		public once(event: 'server.ready', listener: (server: ServerNode) => void): this;
 		public once(event: string, listener: Function): this;
 
-		public serve(name: string, port?: number, hostname?: string, backlog?: number, listeningListener?: Function): this;
-		public serve(name: string, port?: number, hostname?: string, listeningListener?: Function): this;
-		public serve(name: string, port?: number, backlog?: number, listeningListener?: Function): this;
-		public serve(name: string, port?: number, listeningListener?: Function): this;
-		public serve(name: string, path: string, backlog?: number, listeningListener?: Function): this;
-		public serve(name: string, path: string, listeningListener?: Function): this;
-		public serve(name: string, options: ListenOptions, listeningListener?: Function): this;
-		public serve(name: string, handle: any, backlog?: number, listeningListener?: Function): this;
-		public serve(name: string, handle: any, listeningListener?: Function): this;
-		public broadcast<T = any>(data: any): Promise<Array<T>>;
-		public sendTo<T = any>(name: string | Socket, data: any, receptive?: boolean): Promise<T>;
-		public pingTo(name: string | Socket): Promise<number>;
-		public connectTo(name: string, options: SocketConnectOpts, connectionListener?: Function): Promise<Socket>;
-		public connectTo(name: string, port: number, host: string, connectionListener?: Function): Promise<Socket>;
-		public connectTo(name: string, port: number, connectionListener?: Function): Promise<Socket>;
-		public connectTo(name: string, path: string, connectionListener?: Function): Promise<Socket>;
-		public disconnectFrom(name: string): void;
+		public off(event: 'client.connect', listener: (client: NodeSocket | NodeServerClient) => void): this;
+		public off(event: 'client.destroy', listener: (client: NodeSocket | NodeServerClient) => void): this;
+		public off(event: 'client.disconnect', listener: (client: NodeSocket | NodeServerClient) => void): this;
+		public off(event: 'client.identify', listener: (client: NodeServerClient) => void): this;
+		public off(event: 'client.ready', listener: (client: NodeSocket) => void): this;
+		public off(event: 'error', listener: (error: Error, node: NodeServer | NodeServerClient | NodeSocket) => void): this;
+		public off(event: 'message', listener: (message: NodeMessage) => void): this;
+		public off(event: 'raw', listener: (node: NodeServerClient | NodeSocket, buffer: Buffer) => void): this;
+		public off(event: 'server.destroy', listener: (server: ServerNode) => void): this;
+		public off(event: 'server.ready', listener: (server: ServerNode) => void): this;
+		public off(event: string, listener: Function): this;
 
-		private _getSocket(name: string | Socket): Socket | null;
-		private _destroySocket(socketName: string, socket: Socket, server: boolean): void;
-		private _onDataMessage(name: string, socket: Socket, buffer: Buffer): void;
-		private _handleMessage(name: string, socket: Socket, parsedData: { id: string, receptive: boolean, data: any }): void;
-		private _unPackMessage(name: string, socket: Socket, buffer: Buffer): void;
-		private static packMessage(id: string, message: any, receptive?: boolean): Buffer;
-		private static _getMessageDetails(message: any): [number, Buffer];
-		private static createID(): string;
+		public broadcast<T = any>(data: any, options: BroadcastOptions): Promise<Array<T>>;
+		public connectTo(name: string, options: SocketConnectOpts, connectionListener?: Function): Promise<NodeSocket>;
+		public connectTo(name: string, path: string, connectionListener?: Function): Promise<NodeSocket>;
+		public connectTo(name: string, port: number, connectionListener?: Function): Promise<NodeSocket>;
+		public connectTo(name: string, port: number, host: string, connectionListener?: Function): Promise<NodeSocket>;
+		public disconnectFrom(name: string): Promise<boolean>;
+		public sendTo<T = any>(name: string | Socket, data: any, receptive?: boolean): Promise<T>;
+		public serve(handle: any, backlog?: number, listeningListener?: Function): this;
+		public serve(handle: any, listeningListener?: Function): this;
+		public serve(options: ListenOptions, listeningListener?: Function): this;
+		public serve(path: string, backlog?: number, listeningListener?: Function): this;
+		public serve(path: string, listeningListener?: Function): this;
+		public serve(port?: number, backlog?: number, listeningListener?: Function): this;
+		public serve(port?: number, hostname?: string, backlog?: number, listeningListener?: Function): this;
+		public serve(port?: number, hostname?: string, listeningListener?: Function): this;
+		public serve(port?: number, listeningListener?: Function): this;
 	}
 
-	export interface NodeOptions {
+	export class Base {
+		constructor(node: Node, name?: string);
+		public node: Node;
+		public name: string | null;
+	}
+
+	export class SocketHandler extends Base {
+		private socket: Socket;
+		private queue: Queue;
+		public send<T = any>(data: any, receptive?: boolean): Promise<T>;
+		public disconnect(): boolean;
+		public ping(): Promise<number>;
+
+		public on(event: 'close', listener: (had_error: boolean) => void): this;
+		public on(event: 'connect', listener: () => void): this;
+		public on(event: 'data', listener: (data: Buffer) => void): this;
+		public on(event: 'drain', listener: () => void): this;
+		public on(event: 'end', listener: () => void): this;
+		public on(event: 'error', listener: (err: Error) => void): this;
+		public on(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
+		public on(event: 'timeout', listener: () => void): this;
+		public on(event: string, listener: (...args: any[]) => void): this;
+
+		public once(event: 'close', listener: (had_error: boolean) => void): this;
+		public once(event: 'connect', listener: () => void): this;
+		public once(event: 'data', listener: (data: Buffer) => void): this;
+		public once(event: 'drain', listener: () => void): this;
+		public once(event: 'end', listener: () => void): this;
+		public once(event: 'error', listener: (err: Error) => void): this;
+		public once(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
+		public once(event: 'timeout', listener: () => void): this;
+		public once(event: string, listener: (...args: any[]) => void): this;
+
+		public off(event: 'close', listener: (had_error: boolean) => void): this;
+		public off(event: 'connect', listener: () => void): this;
+		public off(event: 'data', listener: (data: Buffer) => void): this;
+		public off(event: 'drain', listener: () => void): this;
+		public off(event: 'end', listener: () => void): this;
+		public off(event: 'error', listener: (err: Error) => void): this;
+		public off(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
+		public off(event: 'timeout', listener: () => void): this;
+		public off(event: string, listener: (...args: any[]) => void): this;
+
+		private _handleMessage(data: { id: string, receptive: boolean, data: any }): NodeMessage | null;
+	}
+
+	export class NodeServer {
+		constructor(node: Node);
+		public node: Node;
+		public readonly name: string;
+		private server: Server;
+		private clients: Map<string, NodeServerClient>;
+		public get(name: NodeResolvable): NodeServer | NodeServerClient;
+		public has(name: NodeResolvable): boolean;
+		public broadcast(data: any, options: { receptive: false, filter?: RegExp }): Promise<Array<void>>;
+		public broadcast<T = any>(data: any, options?: BroadcastOptions): Promise<Array<T>>;
+		public sendTo(name: NodeResolvable, data: any, receptive: false): Promise<void>;
+		public sendTo<T = any>(name: NodeResolvable, data: any, receptive?: boolean): Promise<T>;
+		public connect(handle: any, backlog?: number, listeningListener?: Function): Promise<void>;
+		public connect(handle: any, listeningListener?: Function): Promise<void>;
+		public connect(options: ListenOptions, listeningListener?: Function): Promise<void>;
+		public connect(path: string, backlog?: number, listeningListener?: Function): Promise<void>;
+		public connect(path: string, listeningListener?: Function): Promise<void>;
+		public connect(port?: number, backlog?: number, listeningListener?: Function): Promise<void>;
+		public connect(port?: number, hostname?: string, backlog?: number, listeningListener?: Function): Promise<void>;
+		public connect(port?: number, hostname?: string, listeningListener?: Function): Promise<void>;
+		public connect(port?: number, listeningListener?: Function): Promise<void>;
+		public disconnect(): boolean;
+
+		private _onConnection(socket: Socket): void;
+		private _onError(error: Error): void;
+		private _onClose(): void;
+	}
+
+	export class NodeServerClient extends SocketHandler {
+		constructor(node: Node, server: NodeServer, socket: Socket);
+		public server: NodeServer;
+		public status: number;
+		public setup(): void;
+		public disconnect(): boolean;
+
+		private _onData(data: Buffer): void;
+		private _onError(error: Error): void;
+		private _onClose(): void;
+	}
+
+	export class NodeSocket extends SocketHandler {
+		constructor(node: Node, name: string, socket: Socket);
+		public retriesRemaining: number;
+		private _reconnectionTimeout: NodeJS.Timer | null;
+
+		public connect(options: SocketConnectOpts, connectionListener?: Function): Promise<this>;
+		public connect(path: string, connectionListener?: Function): Promise<this>;
+		public connect(port: number, connectionListener?: Function): Promise<this>;
+		public connect(port: number, host: string, connectionListener?: Function): Promise<this>;
+		public disconnect(): boolean;
+
+		private _onData(data: Buffer): void;
+		private _onConnect(): void;
+		private _onClose(...options: any[]): void;
+		private _onError(error: Error): void;
+	}
+
+	export class Queue extends Map<string, QueueEntry> {
+		constructor(nodeSocket: NodeSocket | NodeServerClient);
+		public nodeSocket: NodeSocket | NodeServerClient;
+		private _rest: Buffer | null;
+		public readonly node: Node;
+		public readonly name: string;
+		private readonly socket: Socket;
+		public process(buffer: Buffer): Iterator<{ id: string, receptive: boolean, data: any }>;
+		public flush(): void;
+
+		private _readMessage(body: Buffer, type: string): any;
+	}
+
+	type BroadcastOptions = {
+		receptive?: boolean;
+		filter?: RegExp;
+	};
+
+	type NodeResolvable = string | NodeSocket | NodeServerClient | Socket;
+
+	type NodeOptions = {
 		maxRetries?: number;
 		retryTime?: number;
 	}
 
-	export interface NodeSocket {
-		readonly name: string;
-		socket: Socket | null;
-		retriesRemaining: number;
-		_reconnectionTimeout: NodeJS.Timer;
-	}
-
-	export type NodeMessage = Readonly<{
+	type NodeMessage = Readonly<{
 		id: string;
 		data: any;
 		from: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
-declare module 'ipc-link-core' {
-	
+declare module 'veza' {
+
 	import { EventEmitter } from 'events';
 	import { Server, Socket, ListenOptions, SocketConnectOpts } from 'net';
 	import { resolve } from 'dns';
@@ -68,8 +68,10 @@ declare module 'ipc-link-core' {
 
 		private _destroySocket(socketName: string, socket: Socket, server: boolean): void;
 		private _onDataMessage(name: string, socket: Socket, buffer: Buffer): void;
-		private static unPackMessage(buffer: Buffer): [string, boolean, any];
+		private _handleMessage(name: string, socket: Socket, parsedData: { id: string, receptive: boolean, data: any }): void;
+		private _unPackMessage(name: string, socket: Socket, buffer: Buffer): void;
 		private static packMessage(id: string, message: any, receptive?: boolean): Buffer;
+		private static _getMessageDetails(message: any): [number, Buffer];
 		private static createID(): string;
 	}
 
@@ -90,7 +92,7 @@ declare module 'ipc-link-core' {
 		public readonly data: any;
 		public readonly from: string;
 		public readonly receptive: boolean;
-		public reply(content: any): boolean;
+		public reply(content: any): void;
 	}
 
 	interface QueueEntry {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -47,13 +47,15 @@ declare module 'veza' {
 		public off(event: 'server.ready', listener: (server: NodeServer) => void): this;
 		public off(event: string, listener: Function): this;
 
-		public broadcast<T = any>(data: any, options: BroadcastOptions): Promise<Array<T>>;
+		public broadcast(data: any, options: { receptive: false } & BroadcastOptions): Promise<Array<void>>;
+		public broadcast<T = any>(data: any, options?: BroadcastOptions): Promise<Array<T>>;
 		public connectTo(name: string, options: SocketConnectOpts, connectionListener?: Function): Promise<NodeSocket>;
 		public connectTo(name: string, path: string, connectionListener?: Function): Promise<NodeSocket>;
 		public connectTo(name: string, port: number, connectionListener?: Function): Promise<NodeSocket>;
 		public connectTo(name: string, port: number, host: string, connectionListener?: Function): Promise<NodeSocket>;
 		public disconnectFrom(name: string): Promise<boolean>;
-		public sendTo<T = any>(name: string | Socket, data: any, receptive?: boolean): Promise<T>;
+		public sendTo(name: string | Socket, data: any, options: { receptive: false } & SendOptions): Promise<void>;
+		public sendTo<T = any>(name: string | Socket, data: any, options?: SendOptions): Promise<T>;
 		public serve(handle: any, backlog?: number, listeningListener?: Function): this;
 		public serve(handle: any, listeningListener?: Function): this;
 		public serve(options: ListenOptions, listeningListener?: Function): this;
@@ -74,7 +76,8 @@ declare module 'veza' {
 	export class SocketHandler extends Base {
 		private socket: Socket;
 		private queue: Queue;
-		public send<T = any>(data: any, options?: { receptive?: boolean, timeout: number }): Promise<T>;
+		public send(data: any, options: SendOptions & { receptive: false }): Promise<void>;
+		public send<T = any>(data: any, options?: SendOptions): Promise<T>;
 		public disconnect(): boolean;
 		public ping(): Promise<number>;
 
@@ -119,10 +122,10 @@ declare module 'veza' {
 		private clients: Map<string, NodeServerClient>;
 		public get(name: NodeResolvable): NodeServer | NodeServerClient;
 		public has(name: NodeResolvable): boolean;
-		public broadcast(data: any, options: { receptive: false, filter?: RegExp }): Promise<Array<void>>;
+		public broadcast(data: any, options: BroadcastOptions & { receptive: false }): Promise<Array<void>>;
 		public broadcast<T = any>(data: any, options?: BroadcastOptions): Promise<Array<T>>;
-		public sendTo(name: NodeResolvable, data: any, receptive: false): Promise<void>;
-		public sendTo<T = any>(name: NodeResolvable, data: any, receptive?: boolean): Promise<T>;
+		public sendTo(name: NodeResolvable, data: any, options: SendOptions & { receptive: false }): Promise<void>;
+		public sendTo<T = any>(name: NodeResolvable, data: any, options?: SendOptions): Promise<T>;
 		public connect(handle: any, backlog?: number, listeningListener?: Function): Promise<void>;
 		public connect(handle: any, listeningListener?: Function): Promise<void>;
 		public connect(options: ListenOptions, listeningListener?: Function): Promise<void>;
@@ -193,8 +196,12 @@ declare module 'veza' {
 	}
 
 	type BroadcastOptions = {
-		receptive?: boolean;
 		filter?: RegExp;
+	} & SendOptions;
+
+	type SendOptions = {
+		receptive?: boolean;
+		timeout?: number;
 	};
 
 	type NodeResolvable = string | NodeSocket | NodeServerClient | Socket;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -59,14 +59,15 @@ declare module 'veza' {
 		public serve(name: string, handle: any, backlog?: number, listeningListener?: Function): this;
 		public serve(name: string, handle: any, listeningListener?: Function): this;
 		public broadcast<T = any>(data: any): Promise<Array<T>>;
-		public sendTo<T = any>(name: string, data: any, receptive?: boolean): Promise<T>;
-		public pingTo(name: string): Promise<number>;
+		public sendTo<T = any>(name: string | Socket, data: any, receptive?: boolean): Promise<T>;
+		public pingTo(name: string | Socket): Promise<number>;
 		public connectTo(name: string, options: SocketConnectOpts, connectionListener?: Function): Promise<Socket>;
 		public connectTo(name: string, port: number, host: string, connectionListener?: Function): Promise<Socket>;
 		public connectTo(name: string, port: number, connectionListener?: Function): Promise<Socket>;
 		public connectTo(name: string, path: string, connectionListener?: Function): Promise<Socket>;
 		public disconnectFrom(name: string): void;
 
+		private _getSocket(name: string | Socket): Socket | null;
 		private _destroySocket(socketName: string, socket: Socket, server: boolean): void;
 		private _onDataMessage(name: string, socket: Socket, buffer: Buffer): void;
 		private _handleMessage(name: string, socket: Socket, parsedData: { id: string, receptive: boolean, data: any }): void;
@@ -97,8 +98,9 @@ declare module 'veza' {
 	}>;
 
 	interface QueueEntry {
-		resolve(data: any): void;
-		reject(data: any): void;
+		socket: Socket;
+		resolve: (data: any) => void;
+		reject: (data: any) => void;
 	}
 
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -74,7 +74,7 @@ declare module 'veza' {
 	export class SocketHandler extends Base {
 		private socket: Socket;
 		private queue: Queue;
-		public send<T = any>(data: any, receptive?: boolean): Promise<T>;
+		public send<T = any>(data: any, options?: { receptive?: boolean, timeout: number }): Promise<T>;
 		public disconnect(): boolean;
 		public ping(): Promise<number>;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -11,6 +11,7 @@ declare module 'veza' {
 		public server: Server | null;
 		public readonly name: string;
 		public readonly sockets: Map<string, NodeSocket>;
+		private _remainingBuffer: Buffer | null;
 		private readonly _queue: Map<string, QueueEntry>;
 		private readonly _serverNodes: Map<string, Socket>;
 


### PR DESCRIPTION
### Description of the PR

This PR contains a rewrite of veza from scratch, interface-level changes include the rename of the events' names, the change of `Node#sendTo` to take an options object instead of `receptive: boolean`, RegExp filter for broadcast, and so on.

Additionally, the rewrite makes veza follow OOP much better, and fixes many bugs.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) API/interface.
- [x] This PR adds methods or properties to the API/interface.
- [x] This PR removes or renames methods or properties in the API/interface.
