### PR TITLE
Update NodeMessage.ts

### DIFF
--- a/src/lib/Structures/NodeMessage.ts
+++ b/src/lib/Structures/NodeMessage.ts
@@ -51,7 +51,7 @@ export class NodeMessage {
 	 * @param content The content to send.
 	 */
 	public reply(content: unknown): void {
-		if (this.receptive) {
+		if (this.receptive && this.client.socket.writable) {
 			this.client.socket!.write(createFromID(this.id, false, serialize(content)));
 		}
 	}


### PR DESCRIPTION
I've been using Veza for a while for my Discord bot because it's used by Kurasuta which is my sharding manager. Ever since I started using Veza I noticed the issue that it sometimes tries to write on the Socket when it cannot. I've reported this on 12/07/2020 in Veza's support server, I showed my temporary fix. There have been no changes since then and it's starting to annoy me that I have to change it manually every time otherwise it crashes my entire process when I restart separate clusters. This change should only be temporary until a real fix has been implemented but it will save me and other bot developers a lot of time and effort to constantly update this line.  Although it falls silent when it should at least throw an error I've been using it like this in production with 98k servers without any issues for the past months.

### Description of the PR


### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) API/interface.
- [ ] This PR adds methods or properties to the API/interface.
- [ ] This PR removes or renames methods or properties in the API/interface.
